### PR TITLE
include x-pack directory in full install

### DIFF
--- a/Formula/kibana-full.rb
+++ b/Formula/kibana-full.rb
@@ -21,6 +21,7 @@ class KibanaFull < Formula
       "src",
       "target",
       "webpackShims",
+      "x-pack",
     )
 
     cd prefix do


### PR DESCRIPTION
Fixes https://github.com/elastic/homebrew-tap/issues/5

Looks like the Kibana formula doesn't include the somewhat new root `x-pack` directory.