### PR TITLE
Enable Kibana installs outside of /usr/local

### DIFF
--- a/Formula/kibana-full.rb
+++ b/Formula/kibana-full.rb
@@ -23,10 +23,12 @@ class KibanaFull < Formula
       "x-pack",
     )
 
-    Dir.foreach(libexec/"bin") do |f|
-      next if f == "." || f == ".."
-      (bin/"#{f}").write_env_script(libexec/"bin"/f, { "KIBANA_PATH_CONF" => etc/"kibana/kibana", "DATA_PATH" => var/"lib/kibana/data" })
+    Pathname.glob(libexec/"bin/*") do |f|
+      next if f.directory?
+      bin.install libexec/"bin"/f
     end
+    bin.env_script_all_files(libexec/"bin", { "KIBANA_PATH_CONF" => etc/"kibana/kibana", "DATA_PATH" => var/"lib/kibana/data" })
+
 
     cd libexec do
       packaged_config = IO.read "config/kibana.yml"

--- a/Formula/kibana-full.rb
+++ b/Formula/kibana-full.rb
@@ -29,7 +29,6 @@ class KibanaFull < Formula
     end
     bin.env_script_all_files(libexec/"bin", { "KIBANA_PATH_CONF" => etc/"kibana/kibana", "DATA_PATH" => var/"lib/kibana/data" })
 
-
     cd libexec do
       packaged_config = IO.read "config/kibana.yml"
       IO.write "config/kibana.yml", "path.data: #{var}/lib/kibana/data\n" + packaged_config

--- a/Formula/kibana-full.rb
+++ b/Formula/kibana-full.rb
@@ -8,7 +8,7 @@ class KibanaFull < Formula
   conflicts_with "kibana-oss"
 
   def install
-    prefix.install(
+    libexec.install(
       "bin",
       "built_assets",
       "config",
@@ -23,7 +23,12 @@ class KibanaFull < Formula
       "x-pack",
     )
 
-    cd prefix do
+    Dir.foreach(libexec/"bin") do |f|
+      next if f == "." || f == ".."
+      (bin/"#{f}").write_env_script(libexec/"bin"/f, { "KIBANA_PATH_CONF" => etc/"kibana/kibana", "DATA_PATH" => var/"lib/kibana/data" })
+    end
+
+    cd libexec do
       packaged_config = IO.read "config/kibana.yml"
       IO.write "config/kibana.yml", "path.data: #{var}/lib/kibana/data\n" + packaged_config
       (etc/"kibana").install Dir["config/*"]
@@ -33,7 +38,7 @@ class KibanaFull < Formula
   end
 
   def post_install
-    ln_s etc/"kibana", prefix/"config"
+    (var/"lib/kibana/data").mkpath
     (prefix/"plugins").mkdir
   end
 

--- a/Formula/kibana-full.rb
+++ b/Formula/kibana-full.rb
@@ -27,7 +27,7 @@ class KibanaFull < Formula
       next if f.directory?
       bin.install libexec/"bin"/f
     end
-    bin.env_script_all_files(libexec/"bin", { "KIBANA_PATH_CONF" => etc/"kibana/kibana", "DATA_PATH" => var/"lib/kibana/data" })
+    bin.env_script_all_files(libexec/"bin", { "KIBANA_PATH_CONF" => etc/"kibana", "DATA_PATH" => var/"lib/kibana/data" })
 
     cd libexec do
       packaged_config = IO.read "config/kibana.yml"

--- a/Formula/kibana-oss.rb
+++ b/Formula/kibana-oss.rb
@@ -8,7 +8,7 @@ class KibanaOss < Formula
   conflicts_with "kibana-full"
 
   def install
-    prefix.install(
+    libexec.install(
       "bin",
       "built_assets",
       "config",
@@ -22,7 +22,12 @@ class KibanaOss < Formula
       "webpackShims",
     )
 
-    cd prefix do
+    Dir.foreach(libexec/"bin") do |f|
+      next if f == "." || f == ".."
+      (bin/"#{f}").write_env_script(libexec/"bin"/f, { "KIBANA_PATH_CONF" => etc/"kibana", "DATA_PATH" => var/"lib/kibana/data" })
+    end
+
+    cd libexec do
       packaged_config = IO.read "config/kibana.yml"
       IO.write "config/kibana.yml", "path.data: #{var}/lib/kibana/data\n" + packaged_config
       (etc/"kibana").install Dir["config/*"]
@@ -32,7 +37,7 @@ class KibanaOss < Formula
   end
 
   def post_install
-    ln_s etc/"kibana", prefix/"config"
+    (var/"lib/kibana/data").mkpath
     (prefix/"plugins").mkdir
   end
 

--- a/Formula/kibana-oss.rb
+++ b/Formula/kibana-oss.rb
@@ -26,7 +26,7 @@ class KibanaOss < Formula
       next if f.directory?
       bin.install libexec/"bin"/f
     end
-    bin.env_script_all_files(libexec/"bin", { "KIBANA_PATH_CONF" => etc/"kibana/kibana", "DATA_PATH" => var/"lib/kibana/data" })
+    bin.env_script_all_files(libexec/"bin", { "KIBANA_PATH_CONF" => etc/"kibana", "DATA_PATH" => var/"lib/kibana/data" })
 
     cd libexec do
       packaged_config = IO.read "config/kibana.yml"

--- a/Formula/kibana-oss.rb
+++ b/Formula/kibana-oss.rb
@@ -22,10 +22,11 @@ class KibanaOss < Formula
       "webpackShims",
     )
 
-    Dir.foreach(libexec/"bin") do |f|
-      next if f == "." || f == ".."
-      (bin/"#{f}").write_env_script(libexec/"bin"/f, { "KIBANA_PATH_CONF" => etc/"kibana", "DATA_PATH" => var/"lib/kibana/data" })
+    Pathname.glob(libexec/"bin/*") do |f|
+      next if f.directory?
+      bin.install libexec/"bin"/f
     end
+    bin.env_script_all_files(libexec/"bin", { "KIBANA_PATH_CONF" => etc/"kibana/kibana", "DATA_PATH" => var/"lib/kibana/data" })
 
     cd libexec do
       packaged_config = IO.read "config/kibana.yml"


### PR DESCRIPTION
This commit addresses some issues that prevented Kibana from being installed outside of /usr/local, the officially supported path for Homebrew and the Elastic Homebrew tap. To address these issues, we no longer rely on symlinks outside of the prefix to the configuration directory, instead we now rely on configuring these paths in the wrapper scripts that start Kibana and its CLI tools.