### PR TITLE
Add bottle unneeded to tap formulae

### DIFF
--- a/Formula/apm-server-full.rb
+++ b/Formula/apm-server-full.rb
@@ -7,6 +7,8 @@ class ApmServerFull < Formula
   conflicts_with "apm-server"
   conflicts_with "apm-server-oss"
 
+  bottle :unneeded
+
   def install
     ["fields.yml", "ingest", "kibana", "module"].each { |d| libexec.install d if File.exist?(d) }
     (libexec/"bin").install "apm-server"

--- a/Formula/apm-server-oss.rb
+++ b/Formula/apm-server-oss.rb
@@ -7,6 +7,8 @@ class ApmServerOss < Formula
   conflicts_with "apm-server"
   conflicts_with "apm-server-full"
 
+  bottle :unneeded
+
   def install
     ["fields.yml", "ingest", "kibana", "module"].each { |d| libexec.install d if File.exist?(d) }
     (libexec/"bin").install "apm-server"

--- a/Formula/auditbeat-full.rb
+++ b/Formula/auditbeat-full.rb
@@ -7,6 +7,8 @@ class AuditbeatFull < Formula
   conflicts_with "auditbeat"
   conflicts_with "auditbeat-oss"
 
+  bottle :unneeded
+
   def install
     ["fields.yml", "ingest", "kibana", "module"].each { |d| libexec.install d if File.exist?(d) }
     (libexec/"bin").install "auditbeat"

--- a/Formula/auditbeat-oss.rb
+++ b/Formula/auditbeat-oss.rb
@@ -7,6 +7,8 @@ class AuditbeatOss < Formula
   conflicts_with "auditbeat"
   conflicts_with "auditbeat-full"
 
+  bottle :unneeded
+
   def install
     ["fields.yml", "ingest", "kibana", "module"].each { |d| libexec.install d if File.exist?(d) }
     (libexec/"bin").install "auditbeat"

--- a/Formula/elasticsearch-full.rb
+++ b/Formula/elasticsearch-full.rb
@@ -7,6 +7,8 @@ class ElasticsearchFull < Formula
   conflicts_with "elasticsearch"
   conflicts_with "elasticsearch-oss"
 
+  bottle :unneeded
+
   def cluster_name
     "elasticsearch_#{ENV["USER"]}"
   end

--- a/Formula/elasticsearch-oss.rb
+++ b/Formula/elasticsearch-oss.rb
@@ -7,6 +7,8 @@ class ElasticsearchOss < Formula
   conflicts_with "elasticsearch"
   conflicts_with "elasticsearch-full"
 
+  bottle :unneeded
+
   def cluster_name
     "elasticsearch_#{ENV["USER"]}"
   end

--- a/Formula/filebeat-full.rb
+++ b/Formula/filebeat-full.rb
@@ -7,6 +7,8 @@ class FilebeatFull < Formula
   conflicts_with "filebeat"
   conflicts_with "filebeat-oss"
 
+  bottle :unneeded
+
   def install
     ["fields.yml", "ingest", "kibana", "module"].each { |d| libexec.install d if File.exist?(d) }
     (libexec/"bin").install "filebeat"

--- a/Formula/filebeat-oss.rb
+++ b/Formula/filebeat-oss.rb
@@ -7,6 +7,8 @@ class FilebeatOss < Formula
   conflicts_with "filebeat"
   conflicts_with "filebeat-full"
 
+  bottle :unneeded
+
   def install
     ["fields.yml", "ingest", "kibana", "module"].each { |d| libexec.install d if File.exist?(d) }
     (libexec/"bin").install "filebeat"

--- a/Formula/heartbeat-full.rb
+++ b/Formula/heartbeat-full.rb
@@ -7,6 +7,8 @@ class HeartbeatFull < Formula
   conflicts_with "heartbeat"
   conflicts_with "heartbeat-oss"
 
+  bottle :unneeded
+
   def install
     ["fields.yml", "ingest", "kibana", "module"].each { |d| libexec.install d if File.exist?(d) }
     (libexec/"bin").install "heartbeat"

--- a/Formula/heartbeat-oss.rb
+++ b/Formula/heartbeat-oss.rb
@@ -7,6 +7,8 @@ class HeartbeatOss < Formula
   conflicts_with "heartbeat"
   conflicts_with "heartbeat-full"
 
+  bottle :unneeded
+
   def install
     ["fields.yml", "ingest", "kibana", "module"].each { |d| libexec.install d if File.exist?(d) }
     (libexec/"bin").install "heartbeat"

--- a/Formula/kibana-full.rb
+++ b/Formula/kibana-full.rb
@@ -7,6 +7,8 @@ class KibanaFull < Formula
   conflicts_with "kibana"
   conflicts_with "kibana-oss"
 
+  bottle :unneeded
+
   def install
     libexec.install(
       "bin",

--- a/Formula/kibana-oss.rb
+++ b/Formula/kibana-oss.rb
@@ -7,6 +7,8 @@ class KibanaOss < Formula
   conflicts_with "kibana"
   conflicts_with "kibana-full"
 
+  bottle :unneeded
+
   def install
     libexec.install(
       "bin",

--- a/Formula/logstash-full.rb
+++ b/Formula/logstash-full.rb
@@ -8,6 +8,8 @@ class LogstashFull < Formula
   conflicts_with "logstash"
   conflicts_with "logstash-oss"
 
+  bottle :unneeded
+
   def install
     inreplace "bin/logstash",
               %r{^\. "\$\(cd `dirname \${SOURCEPATH}`\/\.\.; pwd\)\/bin\/logstash\.lib\.sh\"},

--- a/Formula/logstash-oss.rb
+++ b/Formula/logstash-oss.rb
@@ -8,6 +8,8 @@ class LogstashOss < Formula
   conflicts_with "logstash"
   conflicts_with "logstash-full"
 
+  bottle :unneeded
+
   def install
     inreplace "bin/logstash",
               %r{^\. "\$\(cd `dirname \${SOURCEPATH}`\/\.\.; pwd\)\/bin\/logstash\.lib\.sh\"},

--- a/Formula/metricbeat-full.rb
+++ b/Formula/metricbeat-full.rb
@@ -7,6 +7,8 @@ class MetricbeatFull < Formula
   conflicts_with "metricbeat"
   conflicts_with "metricbeat-oss"
 
+  bottle :unneeded
+
   def install
     ["fields.yml", "ingest", "kibana", "module"].each { |d| libexec.install d if File.exist?(d) }
     (libexec/"bin").install "metricbeat"

--- a/Formula/metricbeat-oss.rb
+++ b/Formula/metricbeat-oss.rb
@@ -7,6 +7,8 @@ class MetricbeatOss < Formula
   conflicts_with "metricbeat"
   conflicts_with "metricbeat-full"
 
+  bottle :unneeded
+
   def install
     ["fields.yml", "ingest", "kibana", "module"].each { |d| libexec.install d if File.exist?(d) }
     (libexec/"bin").install "metricbeat"

--- a/Formula/packetbeat-full.rb
+++ b/Formula/packetbeat-full.rb
@@ -7,6 +7,8 @@ class PacketbeatFull < Formula
   conflicts_with "packetbeat"
   conflicts_with "packetbeat-oss"
 
+  bottle :unneeded
+
   def install
     ["fields.yml", "ingest", "kibana", "module"].each { |d| libexec.install d if File.exist?(d) }
     (libexec/"bin").install "packetbeat"

--- a/Formula/packetbeat-oss.rb
+++ b/Formula/packetbeat-oss.rb
@@ -7,6 +7,8 @@ class PacketbeatOss < Formula
   conflicts_with "packetbeat"
   conflicts_with "packetbeat-full"
 
+  bottle :unneeded
+
   def install
     ["fields.yml", "ingest", "kibana", "module"].each { |d| libexec.install d if File.exist?(d) }
     (libexec/"bin").install "packetbeat"


### PR DESCRIPTION
These formula will not be bottled because we unpack the built artifacts directly. Additionally, this escapes some detection on Catalina where it appears the detection on whether or not the formula needs to be installed from source is busted from failing to detect that the development tools are installed. By marking these formula correct as bottle unneeded, we circumvent that problem.

Closes #14