### PR TITLE
Resign ML binaries on installation

### DIFF
--- a/Formula/elasticsearch-full.rb
+++ b/Formula/elasticsearch-full.rb
@@ -43,6 +43,8 @@ class ElasticsearchFull < Formula
       bin.install libexec/"bin"/f
     end
     bin.env_script_all_files(libexec/"bin", {})
+
+    system "codesign", "-f", "-s", "-", "#{libexec}/modules/x-pack-ml/platform/darwin-x86_64/controller.app", "--deep"
   end
 
   def post_install


### PR DESCRIPTION
This commit resigns the ML binaries on installation, as the Homebrew installation process otherwise modifies these artifacts invalidating their signatures. By resigning, we avoid macOS killing the ML binaries for not having valid signatures.

Closes elastic/elasticsearch#48490