### PR TITLE
Adapt to bundling JDK into jdk.app

### DIFF
--- a/Formula/elasticsearch-full.rb
+++ b/Formula/elasticsearch-full.rb
@@ -15,7 +15,7 @@ class ElasticsearchFull < Formula
 
   def install
     # Install everything else into package directory
-    libexec.install "bin", "config", "jdk", "lib", "modules"
+    libexec.install "bin", "config", "jdk.app", "lib", "modules"
 
     inreplace libexec/"bin/elasticsearch-env",
               "if [ -z \"$ES_PATH_CONF\" ]; then ES_PATH_CONF=\"$ES_HOME\"/config; fi",

--- a/Formula/elasticsearch-oss.rb
+++ b/Formula/elasticsearch-oss.rb
@@ -15,7 +15,7 @@ class ElasticsearchOss < Formula
 
   def install
     # Install everything else into package directory
-    libexec.install "bin", "config", "jdk", "lib", "modules"
+    libexec.install "bin", "config", "jdk.app", "lib", "modules"
 
     inreplace libexec/"bin/elasticsearch-env",
               "if [ -z \"$ES_PATH_CONF\" ]; then ES_PATH_CONF=\"$ES_HOME\"/config; fi",


### PR DESCRIPTION
This commit adapts the Elasticsearch Homebrew formulae to the upstream change the bundles the JDK into jdk.app on macOS.