### PR TITLE
Add support of Linuxbrew

### DIFF
--- a/Formula/apm-server-full.rb
+++ b/Formula/apm-server-full.rb
@@ -1,13 +1,19 @@
 class ApmServerFull < Formula
   desc "Server for shipping APM metrics to Elasticsearch"
   homepage "https://www.elastic.co/"
-  url "https://artifacts.elastic.co/downloads/apm-server/apm-server-7.6.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+  if OS.mac?
+    url "https://artifacts.elastic.co/downloads/apm-server/apm-server-7.6.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+    sha256 "18462d96cc6d2e428e2d23fbffe99a6c8b578f844b7172901d856b7e060e4f31"
+  else
+    url "https://artifacts.elastic.co/downloads/apm-server/apm-server-7.6.1-linux-x86_64.tar.gz?tap=elastic/homebrew-tap"
+    sha256 "49166f9d0aa22ad4b05fea5d5ba7c8c555b7fa9afac5665541312a8c6625ea35"
+  end
   version "7.6.1"
-  sha256 "18462d96cc6d2e428e2d23fbffe99a6c8b578f844b7172901d856b7e060e4f31"
-  conflicts_with "apm-server"
-  conflicts_with "apm-server-oss"
 
   bottle :unneeded
+
+  conflicts_with "apm-server"
+  conflicts_with "apm-server-oss"
 
   def install
     ["fields.yml", "ingest", "kibana", "module"].each { |d| libexec.install d if File.exist?(d) }
@@ -66,6 +72,7 @@ class ApmServerFull < Formula
         codec.format:
           string: '%{[transaction]}'
     EOS
+    chmod "go-w", testpath/"config/apm-server.yml" unless OS.mac?
     pid = fork do
       exec bin/"apm-server", "-path.config", testpath/"config", "-path.data", testpath/"data"
     end

--- a/Formula/apm-server-oss.rb
+++ b/Formula/apm-server-oss.rb
@@ -1,13 +1,19 @@
 class ApmServerOss < Formula
   desc "Server for shipping APM metrics to Elasticsearch"
   homepage "https://www.elastic.co/"
-  url "https://artifacts.elastic.co/downloads/apm-server/apm-server-oss-7.6.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+  if OS.mac?
+    url "https://artifacts.elastic.co/downloads/apm-server/apm-server-oss-7.6.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+    sha256 "7842e8c10122f26070da277a492523640b7aec82efb2a5fcdf9c5c6da52ad563"
+  else
+    url "https://artifacts.elastic.co/downloads/apm-server/apm-server-oss-7.6.1-linux-x86_64.tar.gz?tap=elastic/homebrew-tap"
+    sha256 "c665398b138e5617c019aa232f709d236685f47400d82cecca3a4759de9f916c"
+  end
   version "7.6.1"
-  sha256 "7842e8c10122f26070da277a492523640b7aec82efb2a5fcdf9c5c6da52ad563"
-  conflicts_with "apm-server"
-  conflicts_with "apm-server-full"
 
   bottle :unneeded
+
+  conflicts_with "apm-server"
+  conflicts_with "apm-server-full"
 
   def install
     ["fields.yml", "ingest", "kibana", "module"].each { |d| libexec.install d if File.exist?(d) }
@@ -66,6 +72,7 @@ class ApmServerOss < Formula
         codec.format:
           string: '%{[transaction]}'
     EOS
+    chmod "go-w", testpath/"config/apm-server.yml" unless OS.mac?
     pid = fork do
       exec bin/"apm-server", "-path.config", testpath/"config", "-path.data", testpath/"data"
     end

--- a/Formula/auditbeat-full.rb
+++ b/Formula/auditbeat-full.rb
@@ -1,13 +1,19 @@
 class AuditbeatFull < Formula
   desc "Lightweight Shipper for Audit Data"
   homepage "https://www.elastic.co/products/beats/auditbeat"
-  url "https://artifacts.elastic.co/downloads/beats/auditbeat/auditbeat-7.6.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+  if OS.mac?
+    url "https://artifacts.elastic.co/downloads/beats/auditbeat/auditbeat-7.6.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+    sha256 "9b948cce8211ccd469ecf40a6b1d95ea1fc896d196e6ebf1a485a16e530f6cdc"
+  else
+    url "https://artifacts.elastic.co/downloads/beats/auditbeat/auditbeat-7.6.1-linux-x86_64.tar.gz?tap=elastic/homebrew-tap"
+    sha256 "b0cfb8a6b2c241087d0d1db1e44a7280a6733b80c6b3bf9f157fd9b85fb55fff"
+  end
   version "7.6.1"
-  sha256 "9b948cce8211ccd469ecf40a6b1d95ea1fc896d196e6ebf1a485a16e530f6cdc"
-  conflicts_with "auditbeat"
-  conflicts_with "auditbeat-oss"
 
   bottle :unneeded
+
+  conflicts_with "auditbeat"
+  conflicts_with "auditbeat-oss"
 
   def install
     ["fields.yml", "ingest", "kibana", "module"].each { |d| libexec.install d if File.exist?(d) }
@@ -61,6 +67,7 @@ class AuditbeatFull < Formula
         path: "#{testpath}/auditbeat"
         filename: auditbeat
     EOS
+    chmod "go-w", testpath/"config/auditbeat.yml" unless OS.mac?
     pid = fork do
       exec "#{bin}/auditbeat", "-path.config", testpath/"config", "-path.data", testpath/"data"
     end

--- a/Formula/auditbeat-oss.rb
+++ b/Formula/auditbeat-oss.rb
@@ -1,13 +1,19 @@
 class AuditbeatOss < Formula
   desc "Lightweight Shipper for Audit Data"
   homepage "https://www.elastic.co/products/beats/auditbeat"
-  url "https://artifacts.elastic.co/downloads/beats/auditbeat/auditbeat-oss-7.6.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+  if OS.mac?
+    url "https://artifacts.elastic.co/downloads/beats/auditbeat/auditbeat-oss-7.6.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+    sha256 "f13cb4e8aff4765763c9d8b6cd2accf518836f7cbf65a9c214b15351450367f3"
+  else
+    url "https://artifacts.elastic.co/downloads/beats/auditbeat/auditbeat-oss-7.6.1-linux-x86_64.tar.gz?tap=elastic/homebrew-tap"
+    sha256 "da352815eb44a6ca14bfbc7877a4b87e5ecc56f1cd42b96711fc36a3b2722dd9"
+  end
   version "7.6.1"
-  sha256 "f13cb4e8aff4765763c9d8b6cd2accf518836f7cbf65a9c214b15351450367f3"
-  conflicts_with "auditbeat"
-  conflicts_with "auditbeat-full"
 
   bottle :unneeded
+
+  conflicts_with "auditbeat"
+  conflicts_with "auditbeat-full"
 
   def install
     ["fields.yml", "ingest", "kibana", "module"].each { |d| libexec.install d if File.exist?(d) }
@@ -61,6 +67,7 @@ class AuditbeatOss < Formula
         path: "#{testpath}/auditbeat"
         filename: auditbeat
     EOS
+    chmod "go-w", testpath/"config/auditbeat.yml" unless OS.mac?
     pid = fork do
       exec "#{bin}/auditbeat", "-path.config", testpath/"config", "-path.data", testpath/"data"
     end

--- a/Formula/elasticsearch-full.rb
+++ b/Formula/elasticsearch-full.rb
@@ -1,13 +1,19 @@
 class ElasticsearchFull < Formula
   desc "Distributed search & analytics engine"
   homepage "https://www.elastic.co/products/elasticsearch"
-  url "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.6.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+  if OS.mac?
+    url "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.6.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+    sha256 "6364a1b337bbb2ef6dda3da606b8b6780323d2d2f3b26aaba43f2992ebe8e5e0"
+  else
+    url "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.6.1-linux-x86_64.tar.gz?tap=elastic/homebrew-tap"
+    sha256 "25583ddd44a99437958f7f9410cd9746c8230b367d570cdf69e96824a583748a"
+  end
   version "7.6.1"
-  sha256 "6364a1b337bbb2ef6dda3da606b8b6780323d2d2f3b26aaba43f2992ebe8e5e0"
-  conflicts_with "elasticsearch"
-  conflicts_with "elasticsearch-oss"
 
   bottle :unneeded
+
+  conflicts_with "elasticsearch"
+  conflicts_with "elasticsearch-oss"
 
   def cluster_name
     "elasticsearch_#{ENV["USER"]}"
@@ -15,7 +21,12 @@ class ElasticsearchFull < Formula
 
   def install
     # Install everything else into package directory
-    libexec.install "bin", "config", "jdk.app", "lib", "modules"
+    libexec.install "bin", "config", "lib", "modules"
+    if OS.mac?
+      libexec.install "jdk.app"
+    else
+      libexec.install "jdk"
+    end
 
     inreplace libexec/"bin/elasticsearch-env",
               "if [ -z \"$ES_PATH_CONF\" ]; then ES_PATH_CONF=\"$ES_HOME\"/config; fi",
@@ -44,7 +55,7 @@ class ElasticsearchFull < Formula
     end
     bin.env_script_all_files(libexec/"bin", {})
 
-    system "codesign", "-f", "-s", "-", "#{libexec}/modules/x-pack-ml/platform/darwin-x86_64/controller.app", "--deep"
+    system "codesign", "-f", "-s", "-", "#{libexec}/modules/x-pack-ml/platform/darwin-x86_64/controller.app", "--deep" if OS.mac?
   end
 
   def post_install

--- a/Formula/elasticsearch-oss.rb
+++ b/Formula/elasticsearch-oss.rb
@@ -1,13 +1,19 @@
 class ElasticsearchOss < Formula
   desc "Distributed search & analytics engine"
   homepage "https://www.elastic.co/products/elasticsearch"
-  url "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-7.6.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+  if OS.mac?
+    url "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-7.6.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+    sha256 "5527e2f17fa3db13f2d51c8854652e271ec1beaca0edfbbc5126283919586663"
+  else
+    url "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-7.6.1-linux-x86_64.tar.gz?tap=elastic/homebrew-tap"
+    sha256 "cdc1947d8e5bb8d801791608c75f456c1b1b7ae608b2d0bad041cf015d106423"
+  end
   version "7.6.1"
-  sha256 "5527e2f17fa3db13f2d51c8854652e271ec1beaca0edfbbc5126283919586663"
-  conflicts_with "elasticsearch"
-  conflicts_with "elasticsearch-full"
 
   bottle :unneeded
+
+  conflicts_with "elasticsearch"
+  conflicts_with "elasticsearch-full"
 
   def cluster_name
     "elasticsearch_#{ENV["USER"]}"
@@ -15,7 +21,12 @@ class ElasticsearchOss < Formula
 
   def install
     # Install everything else into package directory
-    libexec.install "bin", "config", "jdk.app", "lib", "modules"
+    libexec.install "bin", "config", "lib", "modules"
+    if OS.mac?
+      libexec.install "jdk.app"
+    else
+      libexec.install "jdk"
+    end
 
     inreplace libexec/"bin/elasticsearch-env",
               "if [ -z \"$ES_PATH_CONF\" ]; then ES_PATH_CONF=\"$ES_HOME\"/config; fi",

--- a/Formula/filebeat-full.rb
+++ b/Formula/filebeat-full.rb
@@ -1,13 +1,19 @@
 class FilebeatFull < Formula
   desc "File harvester to ship log files to Elasticsearch or Logstash"
   homepage "https://www.elastic.co/products/beats/filebeat"
-  url "https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-7.6.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+  if OS.mac?
+    url "https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-7.6.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+    sha256 "d7bc7dbbe9b4b6b6cf9b02b320c327e1521a05aff67c940749c29523c08bec9f"
+  else
+    url "https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-7.6.1-linux-x86_64.tar.gz?tap=elastic/homebrew-tap"
+    sha256 "c7643ad2eab3e6efb3efcb7554b7f8c095234e68652ff91240e0027f812b0f84"
+  end
   version "7.6.1"
-  sha256 "d7bc7dbbe9b4b6b6cf9b02b320c327e1521a05aff67c940749c29523c08bec9f"
-  conflicts_with "filebeat"
-  conflicts_with "filebeat-oss"
 
   bottle :unneeded
+
+  conflicts_with "filebeat"
+  conflicts_with "filebeat-oss"
 
   def install
     ["fields.yml", "ingest", "kibana", "module"].each { |d| libexec.install d if File.exist?(d) }
@@ -60,6 +66,7 @@ class FilebeatFull < Formula
         file:
           path: #{testpath}
     EOS
+    chmod "go-w", testpath/"filebeat.yml" unless OS.mac?
 
     (testpath/"log").mkpath
     (testpath/"data").mkpath

--- a/Formula/filebeat-oss.rb
+++ b/Formula/filebeat-oss.rb
@@ -1,13 +1,19 @@
 class FilebeatOss < Formula
   desc "File harvester to ship log files to Elasticsearch or Logstash"
   homepage "https://www.elastic.co/products/beats/filebeat"
-  url "https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-oss-7.6.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+  if OS.mac?
+    url "https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-oss-7.6.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+    sha256 "65aadeb24166b436492e6f2932b4a27af63c1ad2e858863c44fbfbe30212885f"
+  else
+    url "https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-oss-7.6.1-linux-x86_64.tar.gz?tap=elastic/homebrew-tap"
+    sha256 "4bd207f55e8f55744174bddcff5ef5b761345884c62501718c2032471c72d7c3"
+  end
   version "7.6.1"
-  sha256 "65aadeb24166b436492e6f2932b4a27af63c1ad2e858863c44fbfbe30212885f"
-  conflicts_with "filebeat"
-  conflicts_with "filebeat-full"
 
   bottle :unneeded
+
+  conflicts_with "filebeat"
+  conflicts_with "filebeat-full"
 
   def install
     ["fields.yml", "ingest", "kibana", "module"].each { |d| libexec.install d if File.exist?(d) }
@@ -60,6 +66,7 @@ class FilebeatOss < Formula
         file:
           path: #{testpath}
     EOS
+    chmod "go-w", testpath/"filebeat.yml" unless OS.mac?
 
     (testpath/"log").mkpath
     (testpath/"data").mkpath

--- a/Formula/heartbeat-full.rb
+++ b/Formula/heartbeat-full.rb
@@ -1,13 +1,19 @@
 class HeartbeatFull < Formula
   desc "Lightweight Shipper for Uptime Monitoring"
   homepage "https://www.elastic.co/products/beats/heartbeat"
-  url "https://artifacts.elastic.co/downloads/beats/heartbeat/heartbeat-7.6.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+  if OS.mac?
+    url "https://artifacts.elastic.co/downloads/beats/heartbeat/heartbeat-7.6.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+    sha256 "3e062cff6469616fea127f17c8343c3ecd3b0dc9a14711f39f1eeb1fa32efc18"
+  else
+    url "https://artifacts.elastic.co/downloads/beats/heartbeat/heartbeat-7.6.1-linux-x86_64.tar.gz?tap=elastic/homebrew-tap"
+    sha256 "c39b506ecb177a5ceadc1d5a15e800def68e050373d6174ae30f6ed4950e4298"
+  end
   version "7.6.1"
-  sha256 "3e062cff6469616fea127f17c8343c3ecd3b0dc9a14711f39f1eeb1fa32efc18"
-  conflicts_with "heartbeat"
-  conflicts_with "heartbeat-oss"
 
   bottle :unneeded
+
+  conflicts_with "heartbeat"
+  conflicts_with "heartbeat-oss"
 
   def install
     ["fields.yml", "ingest", "kibana", "module"].each { |d| libexec.install d if File.exist?(d) }
@@ -69,6 +75,7 @@ class HeartbeatFull < Formula
         codec.format:
           string: '%{[monitor]}'
     EOS
+    chmod "go-w", testpath/"config/heartbeat.yml" unless OS.mac?
     pid = fork do
       exec bin/"heartbeat", "-path.config", testpath/"config", "-path.data",
                             testpath/"data"

--- a/Formula/heartbeat-oss.rb
+++ b/Formula/heartbeat-oss.rb
@@ -1,13 +1,19 @@
 class HeartbeatOss < Formula
   desc "Lightweight Shipper for Uptime Monitoring"
   homepage "https://www.elastic.co/products/beats/heartbeat"
-  url "https://artifacts.elastic.co/downloads/beats/heartbeat/heartbeat-oss-7.6.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+  if OS.mac?
+    url "https://artifacts.elastic.co/downloads/beats/heartbeat/heartbeat-oss-7.6.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+    sha256 "034005c51ad62f1d6cbab6643f858914f4e728f759155db670464ad21b071e74"
+  else
+    url "https://artifacts.elastic.co/downloads/beats/heartbeat/heartbeat-oss-7.6.1-linux-x86_64.tar.gz?tap=elastic/homebrew-tap"
+    sha256 "240ff546a743d71a2da9b54b8bc085ba9ffd53d7e8243f5d115cfe5e6a5d93d8"
+  end
   version "7.6.1"
-  sha256 "034005c51ad62f1d6cbab6643f858914f4e728f759155db670464ad21b071e74"
-  conflicts_with "heartbeat"
-  conflicts_with "heartbeat-full"
 
   bottle :unneeded
+
+  conflicts_with "heartbeat"
+  conflicts_with "heartbeat-full"
 
   def install
     ["fields.yml", "ingest", "kibana", "module"].each { |d| libexec.install d if File.exist?(d) }
@@ -69,6 +75,7 @@ class HeartbeatOss < Formula
         codec.format:
           string: '%{[monitor]}'
     EOS
+    chmod "go-w", testpath/"config/heartbeat.yml" unless OS.mac?
     pid = fork do
       exec bin/"heartbeat", "-path.config", testpath/"config", "-path.data",
                             testpath/"data"

--- a/Formula/kibana-full.rb
+++ b/Formula/kibana-full.rb
@@ -1,13 +1,19 @@
 class KibanaFull < Formula
   desc "Analytics and search dashboard for Elasticsearch"
   homepage "https://www.elastic.co/products/kibana"
-  url "https://artifacts.elastic.co/downloads/kibana/kibana-7.6.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+  if OS.mac?
+    url "https://artifacts.elastic.co/downloads/kibana/kibana-7.6.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+    sha256 "846efd53d7a7d4ccb41222f3b1f771016a3e904d9116804ed95df417c9e1e842"
+  else
+    url "https://artifacts.elastic.co/downloads/kibana/kibana-7.6.1-linux-x86_64.tar.gz?tap=elastic/homebrew-tap"
+    sha256 "da636529511e707bbbc621dc131ff2ed18f50fe0df30821c375d16c5ba4248f6"
+  end
   version "7.6.1"
-  sha256 "846efd53d7a7d4ccb41222f3b1f771016a3e904d9116804ed95df417c9e1e842"
-  conflicts_with "kibana"
-  conflicts_with "kibana-oss"
 
   bottle :unneeded
+
+  conflicts_with "kibana"
+  conflicts_with "kibana-oss"
 
   def install
     libexec.install(
@@ -27,6 +33,7 @@ class KibanaFull < Formula
 
     Pathname.glob(libexec/"bin/*") do |f|
       next if f.directory?
+
       bin.install libexec/"bin"/f
     end
     bin.env_script_all_files(libexec/"bin", { "KIBANA_PATH_CONF" => etc/"kibana", "DATA_PATH" => var/"lib/kibana/data" })

--- a/Formula/kibana-oss.rb
+++ b/Formula/kibana-oss.rb
@@ -1,13 +1,19 @@
 class KibanaOss < Formula
   desc "Analytics and search dashboard for Elasticsearch"
   homepage "https://www.elastic.co/products/kibana"
-  url "https://artifacts.elastic.co/downloads/kibana/kibana-oss-7.6.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+  if OS.mac?
+    url "https://artifacts.elastic.co/downloads/kibana/kibana-oss-7.6.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+    sha256 "dde6be4d2e7ad104ab552a8c9de5effd3d613677b16280f471bd7dfb251d0c6b"
+  else
+    url "https://artifacts.elastic.co/downloads/kibana/kibana-oss-7.6.1-linux-x86_64.tar.gz?tap=elastic/homebrew-tap"
+    sha256 "6e810e4ec4b2614379f5d66c82240eb03b4d1d50f595530396c832895b91f0aa"
+  end
   version "7.6.1"
-  sha256 "dde6be4d2e7ad104ab552a8c9de5effd3d613677b16280f471bd7dfb251d0c6b"
-  conflicts_with "kibana"
-  conflicts_with "kibana-full"
 
   bottle :unneeded
+
+  conflicts_with "kibana"
+  conflicts_with "kibana-full"
 
   def install
     libexec.install(
@@ -26,6 +32,7 @@ class KibanaOss < Formula
 
     Pathname.glob(libexec/"bin/*") do |f|
       next if f.directory?
+
       bin.install libexec/"bin"/f
     end
     bin.env_script_all_files(libexec/"bin", { "KIBANA_PATH_CONF" => etc/"kibana", "DATA_PATH" => var/"lib/kibana/data" })

--- a/Formula/logstash-full.rb
+++ b/Formula/logstash-full.rb
@@ -4,11 +4,13 @@ class LogstashFull < Formula
   url "https://artifacts.elastic.co/downloads/logstash/logstash-7.6.1.tar.gz?tap=elastic/homebrew-tap"
   version "7.6.1"
   sha256 "6b16f3158829ad820463c7f3ca4cfec433d12d0eafa25be203c92d12ca91da10"
-  depends_on :java => "1.8"
-  conflicts_with "logstash"
-  conflicts_with "logstash-oss"
 
   bottle :unneeded
+
+  depends_on :java => "1.8"
+
+  conflicts_with "logstash"
+  conflicts_with "logstash-oss"
 
   def install
     inreplace "bin/logstash",

--- a/Formula/logstash-oss.rb
+++ b/Formula/logstash-oss.rb
@@ -4,11 +4,13 @@ class LogstashOss < Formula
   url "https://artifacts.elastic.co/downloads/logstash/logstash-oss-7.6.1.tar.gz?tap=elastic/homebrew-tap"
   version "7.6.1"
   sha256 "1dca0e4b302ce12690bf5068e3daad38fba64b5090bf652dca3a5912a1b87e31"
-  depends_on :java => "1.8"
-  conflicts_with "logstash"
-  conflicts_with "logstash-full"
 
   bottle :unneeded
+
+  depends_on :java => "1.8"
+
+  conflicts_with "logstash"
+  conflicts_with "logstash-full"
 
   def install
     inreplace "bin/logstash",

--- a/Formula/metricbeat-full.rb
+++ b/Formula/metricbeat-full.rb
@@ -1,13 +1,19 @@
 class MetricbeatFull < Formula
   desc "Collect metrics from your systems and services"
   homepage "https://www.elastic.co/products/beats/metricbeat"
-  url "https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-7.6.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+  if OS.mac?
+    url "https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-7.6.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+    sha256 "185c8d8d2524b59b7549ff252403b3a38d32db09878730ac54b2b541337b590b"
+  else
+    url "https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-7.6.1-linux-x86_64.tar.gz?tap=elastic/homebrew-tap"
+    sha256 "9230f5b026b878eb0d071e3616cfe6f3f80b5e15243a24494709db58c35f5627"
+  end
   version "7.6.1"
-  sha256 "185c8d8d2524b59b7549ff252403b3a38d32db09878730ac54b2b541337b590b"
-  conflicts_with "metricbeat"
-  conflicts_with "metricbeat-oss"
 
   bottle :unneeded
+
+  conflicts_with "metricbeat"
+  conflicts_with "metricbeat-oss"
 
   def install
     ["fields.yml", "ingest", "kibana", "module"].each { |d| libexec.install d if File.exist?(d) }
@@ -56,6 +62,7 @@ class MetricbeatFull < Formula
         path: #{testpath}/data
         filename: metricbeat
     EOS
+    chmod "go-w", testpath/"config/metricbeat.yml" unless OS.mac?
 
     (testpath/"logs").mkpath
     (testpath/"data").mkpath

--- a/Formula/metricbeat-oss.rb
+++ b/Formula/metricbeat-oss.rb
@@ -1,13 +1,19 @@
 class MetricbeatOss < Formula
   desc "Collect metrics from your systems and services"
   homepage "https://www.elastic.co/products/beats/metricbeat"
-  url "https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-oss-7.6.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+  if OS.mac?
+    url "https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-oss-7.6.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+    sha256 "935d2b759b59dbb3050ad04f5aa12c2049fad74f94313faa0f91141b3d2a99f6"
+  else
+    url "https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-oss-7.6.1-linux-x86_64.tar.gz?tap=elastic/homebrew-tap"
+    sha256 "29501eaff3d4b1de32da6b27bfaa6e6512e12b439ba0809fa5583b73a2898fce"
+  end
   version "7.6.1"
-  sha256 "935d2b759b59dbb3050ad04f5aa12c2049fad74f94313faa0f91141b3d2a99f6"
-  conflicts_with "metricbeat"
-  conflicts_with "metricbeat-full"
 
   bottle :unneeded
+
+  conflicts_with "metricbeat"
+  conflicts_with "metricbeat-full"
 
   def install
     ["fields.yml", "ingest", "kibana", "module"].each { |d| libexec.install d if File.exist?(d) }
@@ -56,6 +62,7 @@ class MetricbeatOss < Formula
         path: #{testpath}/data
         filename: metricbeat
     EOS
+    chmod "go-w", testpath/"config/metricbeat.yml" unless OS.mac?
 
     (testpath/"logs").mkpath
     (testpath/"data").mkpath

--- a/Formula/packetbeat-full.rb
+++ b/Formula/packetbeat-full.rb
@@ -1,13 +1,19 @@
 class PacketbeatFull < Formula
   desc "Lightweight Shipper for Network Data"
   homepage "https://www.elastic.co/products/beats/packetbeat"
-  url "https://artifacts.elastic.co/downloads/beats/packetbeat/packetbeat-7.6.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+  if OS.mac?
+    url "https://artifacts.elastic.co/downloads/beats/packetbeat/packetbeat-7.6.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+    sha256 "d8086a908a62edc7f0ada21c4812923977bb9993c8753d2237a2ba263ee8df8e"
+  else
+    url "https://artifacts.elastic.co/downloads/beats/packetbeat/packetbeat-7.6.1-linux-x86_64.tar.gz?tap=elastic/homebrew-tap"
+    sha256 "3d6946e5ea7ab9f8bd82d6b06077a8c22297e77d1e1b2f9c79ec7bbb3e2dbcd7"
+  end
   version "7.6.1"
-  sha256 "d8086a908a62edc7f0ada21c4812923977bb9993c8753d2237a2ba263ee8df8e"
-  conflicts_with "packetbeat"
-  conflicts_with "packetbeat-oss"
 
   bottle :unneeded
+
+  conflicts_with "packetbeat"
+  conflicts_with "packetbeat-oss"
 
   def install
     ["fields.yml", "ingest", "kibana", "module"].each { |d| libexec.install d if File.exist?(d) }

--- a/Formula/packetbeat-oss.rb
+++ b/Formula/packetbeat-oss.rb
@@ -1,13 +1,19 @@
 class PacketbeatOss < Formula
   desc "Lightweight Shipper for Network Data"
   homepage "https://www.elastic.co/products/beats/packetbeat"
-  url "https://artifacts.elastic.co/downloads/beats/packetbeat/packetbeat-oss-7.6.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+  if OS.mac?
+    url "https://artifacts.elastic.co/downloads/beats/packetbeat/packetbeat-oss-7.6.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+    sha256 "385d8276f8a2ebb11a2af21299ad00179e2481b71ffe119d0b4a5893a762953d"
+  else
+    url "https://artifacts.elastic.co/downloads/beats/packetbeat/packetbeat-oss-7.6.1-linux-x86_64.tar.gz?tap=elastic/homebrew-tap"
+    sha256 "4581d920b0731b17df8d37d49bdf73c3213d768972be49fcf118b1acd91cb522"
+  end
   version "7.6.1"
-  sha256 "385d8276f8a2ebb11a2af21299ad00179e2481b71ffe119d0b4a5893a762953d"
-  conflicts_with "packetbeat"
-  conflicts_with "packetbeat-full"
 
   bottle :unneeded
+
+  conflicts_with "packetbeat"
+  conflicts_with "packetbeat-full"
 
   def install
     ["fields.yml", "ingest", "kibana", "module"].each { |d| libexec.install d if File.exist?(d) }


### PR DESCRIPTION
Homebrew has a fork named Linuxbrew (Homebrew on Linux). Previously, when Elasticsearch was bundled into main repo, there was the formula for [Elasticsearch](https://github.com/Homebrew/linuxbrew-core/blob/master/Formula/elasticsearch.rb), which was the same as in the Homebrew repository. But since the development of Elastic products for macOS is now in this tap, support in the original repository stopped at version 6.8.*. So, there's no alternative for Elasticsearch 7.x on Linuxbrew. Related issue: https://github.com/Homebrew/linuxbrew-core/issues/19670

In this PR I added alternative links to archives for Linux and the necessary code changes.
I checked via `brew install` and `brew test` that all products are successfully installed and tested on Ubuntu 16.04.