### PR TITLE
Increase test sleeps for more testing consistency

### DIFF
--- a/Formula/apm-server-full.rb
+++ b/Formula/apm-server-full.rb
@@ -69,7 +69,7 @@ class ApmServerFull < Formula
     pid = fork do
       exec bin/"apm-server", "-path.config", testpath/"config", "-path.data", testpath/"data"
     end
-    sleep 1
+    sleep 5
 
     begin
       (testpath/"event").write <<~EOS
@@ -80,7 +80,7 @@ class ApmServerFull < Formula
         {"metricset": {"samples": {"go.memstats.heap.sys.bytes": {"value": 61235}}, "timestamp": 1496170422281000}}
       EOS
       system "curl", "-H", "Content-Type: application/x-ndjson", "-XPOST", "localhost:#{port}/intake/v2/events", "--data-binary", "@#{testpath}/event"
-      sleep 1
+      sleep 5
       s = (testpath/"apm-server/apm-server").read
       assert_match "\"id\":\"abcdef1478523690\"", s
     ensure

--- a/Formula/apm-server-oss.rb
+++ b/Formula/apm-server-oss.rb
@@ -69,7 +69,7 @@ class ApmServerOss < Formula
     pid = fork do
       exec bin/"apm-server", "-path.config", testpath/"config", "-path.data", testpath/"data"
     end
-    sleep 1
+    sleep 5
 
     begin
       (testpath/"event").write <<~EOS
@@ -80,7 +80,7 @@ class ApmServerOss < Formula
         {"metricset": {"samples": {"go.memstats.heap.sys.bytes": {"value": 61235}}, "timestamp": 1496170422281000}}
       EOS
       system "curl", "-H", "Content-Type: application/x-ndjson", "-XPOST", "localhost:#{port}/intake/v2/events", "--data-binary", "@#{testpath}/event"
-      sleep 1
+      sleep 5
       s = (testpath/"apm-server/apm-server").read
       assert_match "\"id\":\"abcdef1478523690\"", s
     ensure

--- a/Formula/auditbeat-full.rb
+++ b/Formula/auditbeat-full.rb
@@ -64,7 +64,7 @@ class AuditbeatFull < Formula
     pid = fork do
       exec "#{bin}/auditbeat", "-path.config", testpath/"config", "-path.data", testpath/"data"
     end
-    sleep 5
+    sleep 20
 
     begin
       touch testpath/"files/touch"

--- a/Formula/auditbeat-oss.rb
+++ b/Formula/auditbeat-oss.rb
@@ -64,7 +64,7 @@ class AuditbeatOss < Formula
     pid = fork do
       exec "#{bin}/auditbeat", "-path.config", testpath/"config", "-path.data", testpath/"data"
     end
-    sleep 5
+    sleep 20
 
     begin
       touch testpath/"files/touch"

--- a/Formula/elasticsearch-full.rb
+++ b/Formula/elasticsearch-full.rb
@@ -118,7 +118,7 @@ class ElasticsearchFull < Formula
     pid = testpath/"pid"
     begin
       system "#{bin}/elasticsearch", "-d", "-p", pid, "-Epath.data=#{testpath}/data", "-Epath.logs=#{testpath}/logs", "-Enode.name=test-cli", "-Ehttp.port=#{port}"
-      sleep 15
+      sleep 30
       system "curl", "-XGET", "localhost:#{port}/"
       output = shell_output("curl -s -XGET localhost:#{port}/_cat/nodes")
       assert_match "test-cli", output
@@ -140,7 +140,7 @@ class ElasticsearchFull < Formula
     pid = testpath/"pid"
     begin
       system "#{bin}/elasticsearch", "-d", "-p", pid
-      sleep 10
+      sleep 30
       system "curl", "-XGET", "localhost:#{port}/"
       output = shell_output("curl -s -XGET localhost:#{port}/_cat/nodes")
       assert_match "test-es-path-conf", output

--- a/Formula/elasticsearch-oss.rb
+++ b/Formula/elasticsearch-oss.rb
@@ -117,7 +117,7 @@ class ElasticsearchOss < Formula
     pid = testpath/"pid"
     begin
       system "#{bin}/elasticsearch", "-d", "-p", pid, "-Epath.data=#{testpath}/data", "-Epath.logs=#{testpath}/logs", "-Enode.name=test-cli", "-Ehttp.port=#{port}"
-      sleep 15
+      sleep 30
       system "curl", "-XGET", "localhost:#{port}/"
       output = shell_output("curl -s -XGET localhost:#{port}/_cat/nodes")
       assert_match "test-cli", output
@@ -139,7 +139,7 @@ class ElasticsearchOss < Formula
     pid = testpath/"pid"
     begin
       system "#{bin}/elasticsearch", "-d", "-p", pid
-      sleep 10
+      sleep 30
       system "curl", "-XGET", "localhost:#{port}/"
       output = shell_output("curl -s -XGET localhost:#{port}/_cat/nodes")
       assert_match "test-es-path-conf", output


### PR DESCRIPTION
Increase the sleeps when waiting for processes to start up to reduce
test flakiness.