### PR TITLE
Update for kibana 7.10 directories

### DIFF
--- a/Formula/kibana-full.rb
+++ b/Formula/kibana-full.rb
@@ -12,16 +12,13 @@ class KibanaFull < Formula
   def install
     libexec.install(
       "bin",
-      "built_assets",
       "config",
       "data",
       "node",
       "node_modules",
-      "optimize",
       "package.json",
       "plugins",
       "src",
-      "webpackShims",
       "x-pack",
     )
 

--- a/Formula/kibana-oss.rb
+++ b/Formula/kibana-oss.rb
@@ -12,16 +12,13 @@ class KibanaOss < Formula
   def install
     libexec.install(
       "bin",
-      "built_assets",
       "config",
       "data",
       "node",
       "node_modules",
-      "optimize",
       "package.json",
       "plugins",
       "src",
-      "webpackShims",
     )
 
     Pathname.glob(libexec/"bin/*") do |f|


### PR DESCRIPTION
Some directories are no longer present in the Kibana darwin tarballs, so
they must be removed.

This will be merged at the same time of the 7.10 release.