### PR TITLE
drop dependency on java and ensure code signing

### DIFF
--- a/Formula/logstash-full.rb
+++ b/Formula/logstash-full.rb
@@ -4,7 +4,6 @@ class LogstashFull < Formula
   url "https://artifacts.elastic.co/downloads/logstash/logstash-7.10.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
   version "7.10.1"
   sha256 "b478ce9fbeb5f00d3924e4da6a5b6fbedda5228d3947ffe5acb6ce8c352fd65a"
-  depends_on :java => "1.8"
   conflicts_with "logstash"
   conflicts_with "logstash-oss"
 
@@ -28,7 +27,8 @@ class LogstashFull < Formula
     (libexec/"config").rmtree
 
     bin.install libexec/"bin/logstash", libexec/"bin/logstash-plugin"
-    bin.env_script_all_files(libexec/"bin", Language::Java.java_home_env("1.8"))
+    bin.env_script_all_files(libexec/"bin", {})
+    system "find", "#{libexec}/jdk.app/Contents/Home/bin", "-type", "f", "-exec", "codesign", "-f", "-s", "-", "{}", ";"
   end
 
   def post_install

--- a/Formula/logstash-oss.rb
+++ b/Formula/logstash-oss.rb
@@ -4,7 +4,6 @@ class LogstashOss < Formula
   url "https://artifacts.elastic.co/downloads/logstash/logstash-oss-7.10.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
   version "7.10.1"
   sha256 "8e5b8d2557029de9278361a8bb5ef86144a0d2176bb9c586a4170434e7ba15db"
-  depends_on :java => "1.8"
   conflicts_with "logstash"
   conflicts_with "logstash-full"
 
@@ -28,7 +27,8 @@ class LogstashOss < Formula
     (libexec/"config").rmtree
 
     bin.install libexec/"bin/logstash", libexec/"bin/logstash-plugin"
-    bin.env_script_all_files(libexec/"bin", Language::Java.java_home_env("1.8"))
+    bin.env_script_all_files(libexec/"bin", {})
+    system "find", "#{libexec}/jdk.app/Contents/Home/bin", "-type", "f", "-exec", "codesign", "-f", "-s", "-", "{}", ";"
   end
 
   def post_install


### PR DESCRIPTION
This change removes the need for external jdk as logstash is shipped
with Java 11 since 7.10.0

It also fixes a bug where jdk binaries weren't getting signed causing
the process to be terminated immediately.

fixes #56 