### PR TITLE
Include version in ci automated patch file

### DIFF
--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -19,6 +19,6 @@ git checkout -b "update-$VERSION"
 git add Formula
 git commit -m "Update to $VERSION" -m "Updated by homebrew-tap automation."
 mkdir -p .ci/output
-git format-patch -1 --output=".ci/output/update.patch"
+git format-patch -1 --output=".ci/output/update-$VERSION.patch"
 git checkout -
 


### PR DESCRIPTION
Include the version in the generated patch file which will be used by
release automation.