### PR TITLE
Use dedicated homebrew installation for ci

### DIFF
--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -6,11 +6,13 @@ DOWNLOAD_BASE="$1"
 VERSION="$2"
 
 install_homebrew() {
-  # do an alternative install of homebrew to ensure we have access
-  # to perform brew operations
+  # do an alternative install of homebrew to ensure we have access to
+  # perform brew operations
   # https://docs.brew.sh/Installation#untar-anywhere
-  git clone https://github.com/Homebrew/brew.git ./.ci/build/brew
-  export "PATH=$PWD/.ci/build/brew/bin:$PATH"
+  # note that homebrew needs to be installed somewhere with a shortish
+  # path to avoid relinking dynamic libraries for bundled JDKs
+  git clone https://github.com/Homebrew/brew.git $HOME/brew
+  eval $($HOME/brew/bin/brew shellenv)
 }
 
 # create the directory we'll be doing some work in

--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -5,6 +5,20 @@ set -eou pipefail
 DOWNLOAD_BASE="$1"
 VERSION="$2"
 
+install_homebrew() {
+  # do an alternative install of homebrew to ensure we have access
+  # to perform brew operations
+  # https://docs.brew.sh/Installation#untar-anywhere
+  git clone https://github.com/Homebrew/brew.git ./.ci/build/brew
+  export "PATH=$PWD/.ci/build/brew/bin:$PATH"
+}
+
+# create the directory we'll be doing some work in
+rm -rf .ci/build
+mkdir -p .ci/build
+
+install_homebrew
+
 # update to the new artifacts
 env DOWNLOAD_BASE="$DOWNLOAD_BASE" .ci/update.sh "$VERSION"
 
@@ -15,10 +29,11 @@ env DOWNLOAD_BASE="$DOWNLOAD_BASE" .ci/update.sh "$VERSION"
 .ci/update-to-production-downloads.sh
 
 # create a git patch file with the updates
-git checkout -b "update-$VERSION"
+UPDATE_BRANCH_NAME="update-$VERSION-$(date -u +%Y%m%d%H%M)"
+git checkout -b "$UPDATE_BRANCH_NAME"
 git add Formula
 git commit -m "Update to $VERSION" -m "Updated by homebrew-tap automation."
-mkdir -p .ci/output
-git format-patch -1 --output=".ci/output/update-$VERSION.patch"
+mkdir -p .ci/build/output
+git format-patch -1 --output=".ci/build/output/update-$VERSION.patch"
 git checkout -
 

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -36,6 +36,8 @@ brew_test() {
   brew uninstall --formula "$FORMULA_FILE"
 }
 
+log "Using brew: '$(which brew)'."
+
 brew_test "./Formula/apm-server-full.rb"
 brew_test "./Formula/apm-server-oss.rb"
 brew_test "./Formula/auditbeat-full.rb"

--- a/.ci/update.sh
+++ b/.ci/update.sh
@@ -47,6 +47,8 @@ update() {
   brew uninstall --formula "$FORMULA_FILE"
 }
 
+log "Using brew: '$(which brew)'."
+
 update "./Formula/apm-server-full.rb" "apm-server/apm-server-$VERSION-darwin-x86_64.tar.gz"
 update "./Formula/apm-server-oss.rb" "apm-server/apm-server-oss-$VERSION-darwin-x86_64.tar.gz"
 update "./Formula/auditbeat-full.rb" "beats/auditbeat/auditbeat-$VERSION-darwin-x86_64.tar.gz"

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-.ci/output
+.ci/build


### PR DESCRIPTION
Perform a user install of homebrew and use it during CI testing to avoid
any issues with homebrew configuration on workers.

Also add a timestamp to the local branch name to enable friendlier
re-runs.