### PR TITLE
Use dedicated homebrew installation for ci

### DIFF
--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -5,6 +5,28 @@ set -eou pipefail
 DOWNLOAD_BASE="$1"
 VERSION="$2"
 
+install_homebrew() {
+  # do an alternative install of homebrew to ensure we have access to
+  # perform brew operations
+  # https://docs.brew.sh/Installation#untar-anywhere
+  # note that homebrew needs to be installed somewhere with a shortish
+  # path to avoid issues relinking dynamic libraries
+  # https://github.com/Homebrew/brew/issues/4979
+  rm -rf "/tmp/b"
+  git clone https://github.com/Homebrew/brew.git "/tmp/b"
+  #shellcheck disable=SC2046
+  eval $("/tmp/b/bin/brew" shellenv)
+  # override the default temp directory, by default homebrew does not
+  # allow an install in /tmp otherwise
+  export HOMEBREW_TEMP=/tmp/homebrew-temp
+}
+
+remove_homebrew() {
+  rm -rf "/tmp/b"
+}
+
+install_homebrew
+
 # update to the new artifacts
 env DOWNLOAD_BASE="$DOWNLOAD_BASE" .ci/update.sh "$VERSION"
 
@@ -15,10 +37,13 @@ env DOWNLOAD_BASE="$DOWNLOAD_BASE" .ci/update.sh "$VERSION"
 .ci/update-to-production-downloads.sh
 
 # create a git patch file with the updates
-git checkout -b "update-$VERSION"
+UPDATE_BRANCH_NAME="update-$VERSION-$(date -u +%Y%m%d%H%M)"
+git checkout -b "$UPDATE_BRANCH_NAME"
 git add Formula
 git commit -m "Update to $VERSION" -m "Updated by homebrew-tap automation."
 mkdir -p .ci/output
-git format-patch -1 --output=".ci/output/update-$VERSION.patch"
+git format-patch -1 --stdout > ".ci/output/update-$VERSION.patch"
 git checkout -
+
+remove_homebrew
 

--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -23,6 +23,7 @@ install_homebrew() {
   # override the default temp directory, by default homebrew does not
   # allow an install in /tmp otherwise
   export HOMEBREW_TEMP=/tmp/homebrew-temp
+  rm -rf "$HOMEBREW_TEMP"
 }
 
 install_homebrew

--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -5,6 +5,10 @@ set -eou pipefail
 DOWNLOAD_BASE="$1"
 VERSION="$2"
 
+remove_homebrew() {
+  rm -rf "/tmp/b"
+}
+
 install_homebrew() {
   # do an alternative install of homebrew to ensure we have access to
   # perform brew operations
@@ -12,17 +16,13 @@ install_homebrew() {
   # note that homebrew needs to be installed somewhere with a shortish
   # path to avoid issues relinking dynamic libraries
   # https://github.com/Homebrew/brew/issues/4979
-  rm -rf "/tmp/b"
+  remove_homebrew
   git clone https://github.com/Homebrew/brew.git "/tmp/b"
   #shellcheck disable=SC2046
   eval $("/tmp/b/bin/brew" shellenv)
   # override the default temp directory, by default homebrew does not
   # allow an install in /tmp otherwise
   export HOMEBREW_TEMP=/tmp/homebrew-temp
-}
-
-remove_homebrew() {
-  rm -rf "/tmp/b"
 }
 
 install_homebrew

--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -12,8 +12,8 @@ VERSION="$2"
 # https://github.com/Homebrew/brew/issues/4979
 HOMEBREW_INSTALL_PATH="/tmp/b"
 
-# this environment variable is used by homebrew, the default is override
-# otherwise homebrew does not allow an install in /tmp otherwise
+# this environment variable is used by homebrew, the default is overridden
+# otherwise homebrew does not allow an install in /tmp
 export HOMEBREW_TEMP="/tmp/homebrew-temp"
 
 remove_homebrew() {

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -36,6 +36,8 @@ brew_test() {
   brew uninstall --formula "$FORMULA_FILE"
 }
 
+log "Using brew: '$(which brew)'."
+
 brew_test "./Formula/apm-server-full.rb"
 brew_test "./Formula/apm-server-oss.rb"
 brew_test "./Formula/auditbeat-full.rb"

--- a/.ci/update.sh
+++ b/.ci/update.sh
@@ -28,7 +28,15 @@ update() {
     "$FORMULA_FILE"
 
   log "Installing '${FORMULA_FILE}'."
-  BREW_INSTALL_OUTPUT=$(brew install --formula "$FORMULA_FILE" 2>&1)
+  if BREW_INSTALL_OUTPUT=$(brew install --formula "$FORMULA_FILE" 2>&1)
+  then
+    echo "$BREW_INSTALL_OUTPUT"
+    log "Install successful."
+  else
+    echo "$BREW_INSTALL_OUTPUT"
+    log "The install was unsuccessful, aborting."
+    exit 1
+  fi
 
   log "Picking up the reported new sha256."
   NEW_SHA256=$(echo "$BREW_INSTALL_OUTPUT" | awk '/sha256 / { gsub("\"","");print $2 }')
@@ -46,6 +54,8 @@ update() {
 
   brew uninstall --formula "$FORMULA_FILE"
 }
+
+log "Using brew: '$(which brew)'."
 
 update "./Formula/apm-server-full.rb" "apm-server/apm-server-$VERSION-darwin-x86_64.tar.gz"
 update "./Formula/apm-server-oss.rb" "apm-server/apm-server-oss-$VERSION-darwin-x86_64.tar.gz"


### PR DESCRIPTION
Perform a user install of homebrew to /tmp and use it during CI testing
to avoid issues with homebrew configuration on workers.

Also add a timestamp to the local branch name to enable friendlier
re-runs and show output from from `brew install` when updating.

Use `git format-patch --stdout` because git is too old on some workers
to support the newer `--output` option.