### PR TITLE
[ci] Add common script to prepare env before running test or release scripts

### DIFF
--- a/.ci/README.md
+++ b/.ci/README.md
@@ -10,7 +10,7 @@ The entrypoint for ci `release.sh`:
 .ci/release.sh "$DOWNLOAD_BASE" "$VERSION"
 ```
 
-This invokes the update, test, release preparation, and patch file creation for
+This invokes the update, release preparation, and patch file creation for
 integration with the release process.
 
 # Individual scripts
@@ -35,7 +35,12 @@ Once that is complete, changes can be inspected in the local repository.
 To run the homebrew automated tests, use the following script:
 
 ```bash
-.ci/test.sh
+.ci/test.sh "$DOWNLOAD_BASE" "$VERSION"
+```
+
+For example to run the tests for the `8.0.0-SNAPSHOT` version:
+```bash
+.ci/test.sh "https://snapshots.elastic.co/downloads" "8.0.0-SNAPSHOT"
 ```
 
 This will not make any changes to the repository.

--- a/.ci/prepare-homebrew-env.sh
+++ b/.ci/prepare-homebrew-env.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+# the path to where an alternative install of homebrew is done to ensure we
+# have access to perform 'brew install' commands.
+# note that homebrew needs to be installed somewhere with a shortish
+# path to avoid issues relinking dynamic libraries
+# https://github.com/Homebrew/brew/issues/4979
+HOMEBREW_INSTALL_PATH="/tmp/b"
+
+# this environment variable is used by homebrew, the default is overridden
+# otherwise homebrew does not allow an install in /tmp
+export HOMEBREW_TEMP="/tmp/homebrew-temp"
+
+remove_homebrew() {
+  rm -rf "$HOMEBREW_INSTALL_PATH"
+  rm -rf "$HOMEBREW_TEMP"
+}
+
+# do an alternative install of homebrew to ensure we have access to
+# perform brew operations
+# https://docs.brew.sh/Installation#untar-anywhere
+install_homebrew() {
+  remove_homebrew
+
+  # https://docs.brew.sh/Installation#untar-anywhere
+  git clone https://github.com/Homebrew/brew.git "$HOMEBREW_INSTALL_PATH"
+
+  #shellcheck disable=SC2046
+  eval $("$HOMEBREW_INSTALL_PATH/bin/brew" shellenv)
+}
+
+install_homebrew

--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -5,42 +5,10 @@ set -eou pipefail
 DOWNLOAD_BASE="$1"
 VERSION="$2"
 
-# the path to where an alternative install of homebrew is done to ensure we
-# have access to perform 'brew install' commands.
-# note that homebrew needs to be installed somewhere with a shortish
-# path to avoid issues relinking dynamic libraries
-# https://github.com/Homebrew/brew/issues/4979
-HOMEBREW_INSTALL_PATH="/tmp/b"
-
-# this environment variable is used by homebrew, the default is overridden
-# otherwise homebrew does not allow an install in /tmp
-export HOMEBREW_TEMP="/tmp/homebrew-temp"
-
-remove_homebrew() {
-  rm -rf "$HOMEBREW_INSTALL_PATH"
-  rm -rf "$HOMEBREW_TEMP"
-}
-
-# do an alternative install of homebrew to ensure we have access to
-# perform brew operations
-# https://docs.brew.sh/Installation#untar-anywhere
-install_homebrew() {
-  remove_homebrew
-
-  # https://docs.brew.sh/Installation#untar-anywhere
-  git clone https://github.com/Homebrew/brew.git "$HOMEBREW_INSTALL_PATH"
-
-  #shellcheck disable=SC2046
-  eval $("$HOMEBREW_INSTALL_PATH/bin/brew" shellenv)
-}
-
-install_homebrew
+.ci/prepare-homebrew-env.sh
 
 # update to the new artifacts
 env DOWNLOAD_BASE="$DOWNLOAD_BASE" .ci/update.sh "$VERSION"
-
-# test the formulas
-.ci/test.sh
 
 # update to the final download urls
 .ci/update-to-production-downloads.sh

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -2,6 +2,14 @@
 
 set -euo pipefail
 
+DOWNLOAD_BASE="$1"
+VERSION="$2"
+
+.ci/prepare-homebrew-env.sh
+
+# update to the new artifacts
+env DOWNLOAD_BASE="$DOWNLOAD_BASE" .ci/update.sh "$VERSION"
+
 FAILED_TESTS=""
 
 log() {


### PR DESCRIPTION
This commit makes sure both the release and test scripts can be executed
independently.
Also, the tests are not part anymore of the release script.