### PR TITLE
Adjust installation test

### DIFF
--- a/Formula/elasticsearch-full.rb
+++ b/Formula/elasticsearch-full.rb
@@ -117,7 +117,7 @@ class ElasticsearchFull < Formula
 
     pid = testpath/"pid"
     begin
-      system "#{bin}/elasticsearch", "-d", "-p", pid, "-Epath.data=#{testpath}/data", "-Epath.logs=#{testpath}/logs", "-Enode.name=test-cli", "-Ehttp.port=#{port}"
+      system "#{bin}/elasticsearch", "-d", "-p", pid, "-Expack.security.enabled=false", "-Epath.data=#{testpath}/data", "-Epath.logs=#{testpath}/logs", "-Enode.name=test-cli", "-Ehttp.port=#{port}"
       sleep 30
       system "curl", "-XGET", "localhost:#{port}/"
       output = shell_output("curl -s -XGET localhost:#{port}/_cat/nodes")

--- a/Formula/elasticsearch-full.rb
+++ b/Formula/elasticsearch-full.rb
@@ -140,7 +140,7 @@ class ElasticsearchFull < Formula
 
     pid = testpath/"pid"
     begin
-      system "#{bin}/elasticsearch", "-d", "-p", pid
+      system "#{bin}/elasticsearch", "-d", "-p", pid, "-Expack.security.enabled=false"
       sleep 30
       system "curl", "-XGET", "localhost:#{port}/"
       output = shell_output("curl -s -XGET localhost:#{port}/_cat/nodes")


### PR DESCRIPTION
During installation, we start elasticsearch a couple of times and
check that we can connect to it. Since elastic/elasticsearch#72300
these tests ( and installation for that matter) have been failing
since security is enabled by default and we make requests without
credentials.

This change, as a temporary measure, makes it so that we start
elasticsearch with security explicitly disabled temporarily during
installation so that we can make the necessary connection test
requests without credentials.

In a follow-up, we will adjust the Formula to take advantage of
newly added functionality, set and show the password for the
elastic user during installation (similar to what we do in
elastic/elasticsearch#75144). We can then also use this password
to make the test requests without needing to disable authN.