### PR TITLE
[APM] Adapt tests suite in regards to stack version

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -48,7 +48,12 @@ brew_test() {
 log "Using brew: '$(which brew)'."
 
 brew_test "./Formula/apm-server-full.rb"
-brew_test "./Formula/apm-server-oss.rb"
+
+if [[ $VERSION =~ ^7\.* ]]
+then
+  brew_test "./Formula/apm-server-oss.rb"
+fi
+
 brew_test "./Formula/auditbeat-full.rb"
 brew_test "./Formula/auditbeat-oss.rb"
 brew_test "./Formula/elasticsearch-full.rb"

--- a/.ci/update.sh
+++ b/.ci/update.sh
@@ -58,7 +58,12 @@ update() {
 log "Using brew: '$(which brew)'."
 
 update "./Formula/apm-server-full.rb" "apm-server/apm-server-$VERSION-darwin-x86_64.tar.gz"
-update "./Formula/apm-server-oss.rb" "apm-server/apm-server-oss-$VERSION-darwin-x86_64.tar.gz"
+
+if [[ $VERSION =~ ^7\.* ]]
+then
+  update "./Formula/apm-server-oss.rb" "apm-server/apm-server-oss-$VERSION-darwin-x86_64.tar.gz"
+fi
+
 update "./Formula/auditbeat-full.rb" "beats/auditbeat/auditbeat-$VERSION-darwin-x86_64.tar.gz"
 update "./Formula/auditbeat-oss.rb" "beats/auditbeat/auditbeat-oss-$VERSION-darwin-x86_64.tar.gz"
 update "./Formula/elasticsearch-full.rb" "elasticsearch/elasticsearch-$VERSION-darwin-x86_64.tar.gz"


### PR DESCRIPTION
tested with
- `.ci/test.sh "https://snapshots.elastic.co/downloads" "7.15.0-SNAPSHOT"`
- `.ci/test.sh "https://snapshots.elastic.co/downloads" "8.0.0-SNAPSHOT"`