### PR TITLE
Remove deprecated `bottle :unneeded` to avoid warnings

### DIFF
--- a/Formula/apm-server-full.rb
+++ b/Formula/apm-server-full.rb
@@ -7,8 +7,6 @@ class ApmServerFull < Formula
   conflicts_with "apm-server"
   conflicts_with "apm-server-oss"
 
-  bottle :unneeded
-
   def install
     ["fields.yml", "ingest", "kibana", "module"].each { |d| libexec.install d if File.exist?(d) }
     (libexec/"bin").install "apm-server"

--- a/Formula/apm-server-oss.rb
+++ b/Formula/apm-server-oss.rb
@@ -7,8 +7,6 @@ class ApmServerOss < Formula
   conflicts_with "apm-server"
   conflicts_with "apm-server-full"
 
-  bottle :unneeded
-
   def install
     ["fields.yml", "ingest", "kibana", "module"].each { |d| libexec.install d if File.exist?(d) }
     (libexec/"bin").install "apm-server"

--- a/Formula/auditbeat-full.rb
+++ b/Formula/auditbeat-full.rb
@@ -7,8 +7,6 @@ class AuditbeatFull < Formula
   conflicts_with "auditbeat"
   conflicts_with "auditbeat-oss"
 
-  bottle :unneeded
-
   def install
     ["fields.yml", "ingest", "kibana", "module"].each { |d| libexec.install d if File.exist?(d) }
     (libexec/"bin").install "auditbeat"

--- a/Formula/auditbeat-oss.rb
+++ b/Formula/auditbeat-oss.rb
@@ -7,8 +7,6 @@ class AuditbeatOss < Formula
   conflicts_with "auditbeat"
   conflicts_with "auditbeat-full"
 
-  bottle :unneeded
-
   def install
     ["fields.yml", "ingest", "kibana", "module"].each { |d| libexec.install d if File.exist?(d) }
     (libexec/"bin").install "auditbeat"

--- a/Formula/elasticsearch-full.rb
+++ b/Formula/elasticsearch-full.rb
@@ -6,8 +6,6 @@ class ElasticsearchFull < Formula
   sha256 "ad093b4fe6773363fbc9c17d32a89222e536899b2a41c8dcc47b82a9c1459b6c"
   conflicts_with "elasticsearch"
 
-  bottle :unneeded
-
   def cluster_name
     "elasticsearch_#{ENV["USER"]}"
   end

--- a/Formula/filebeat-full.rb
+++ b/Formula/filebeat-full.rb
@@ -7,8 +7,6 @@ class FilebeatFull < Formula
   conflicts_with "filebeat"
   conflicts_with "filebeat-oss"
 
-  bottle :unneeded
-
   def install
     ["fields.yml", "ingest", "kibana", "module"].each { |d| libexec.install d if File.exist?(d) }
     (libexec/"bin").install "filebeat"

--- a/Formula/filebeat-oss.rb
+++ b/Formula/filebeat-oss.rb
@@ -7,8 +7,6 @@ class FilebeatOss < Formula
   conflicts_with "filebeat"
   conflicts_with "filebeat-full"
 
-  bottle :unneeded
-
   def install
     ["fields.yml", "ingest", "kibana", "module"].each { |d| libexec.install d if File.exist?(d) }
     (libexec/"bin").install "filebeat"

--- a/Formula/heartbeat-full.rb
+++ b/Formula/heartbeat-full.rb
@@ -7,8 +7,6 @@ class HeartbeatFull < Formula
   conflicts_with "heartbeat"
   conflicts_with "heartbeat-oss"
 
-  bottle :unneeded
-
   def install
     ["fields.yml", "ingest", "kibana", "module"].each { |d| libexec.install d if File.exist?(d) }
     (libexec/"bin").install "heartbeat"

--- a/Formula/heartbeat-oss.rb
+++ b/Formula/heartbeat-oss.rb
@@ -7,8 +7,6 @@ class HeartbeatOss < Formula
   conflicts_with "heartbeat"
   conflicts_with "heartbeat-full"
 
-  bottle :unneeded
-
   def install
     ["fields.yml", "ingest", "kibana", "module"].each { |d| libexec.install d if File.exist?(d) }
     (libexec/"bin").install "heartbeat"

--- a/Formula/kibana-full.rb
+++ b/Formula/kibana-full.rb
@@ -6,8 +6,6 @@ class KibanaFull < Formula
   sha256 "7028495cafc4c3454d933b3bd938bfc3b7ee9042323df6013d7233306feac3ef"
   conflicts_with "kibana"
 
-  bottle :unneeded
-
   def install
     libexec.install(
       "bin",

--- a/Formula/logstash-full.rb
+++ b/Formula/logstash-full.rb
@@ -7,8 +7,6 @@ class LogstashFull < Formula
   conflicts_with "logstash"
   conflicts_with "logstash-oss"
 
-  bottle :unneeded
-
   def install
     inreplace "bin/logstash",
               %r{^\. "\$\(cd `dirname \${SOURCEPATH}`\/\.\.; pwd\)\/bin\/logstash\.lib\.sh\"},

--- a/Formula/logstash-oss.rb
+++ b/Formula/logstash-oss.rb
@@ -7,8 +7,6 @@ class LogstashOss < Formula
   conflicts_with "logstash"
   conflicts_with "logstash-full"
 
-  bottle :unneeded
-
   def install
     inreplace "bin/logstash",
               %r{^\. "\$\(cd `dirname \${SOURCEPATH}`\/\.\.; pwd\)\/bin\/logstash\.lib\.sh\"},

--- a/Formula/metricbeat-full.rb
+++ b/Formula/metricbeat-full.rb
@@ -7,8 +7,6 @@ class MetricbeatFull < Formula
   conflicts_with "metricbeat"
   conflicts_with "metricbeat-oss"
 
-  bottle :unneeded
-
   def install
     ["fields.yml", "ingest", "kibana", "module"].each { |d| libexec.install d if File.exist?(d) }
     (libexec/"bin").install "metricbeat"

--- a/Formula/metricbeat-oss.rb
+++ b/Formula/metricbeat-oss.rb
@@ -7,8 +7,6 @@ class MetricbeatOss < Formula
   conflicts_with "metricbeat"
   conflicts_with "metricbeat-full"
 
-  bottle :unneeded
-
   def install
     ["fields.yml", "ingest", "kibana", "module"].each { |d| libexec.install d if File.exist?(d) }
     (libexec/"bin").install "metricbeat"

--- a/Formula/packetbeat-full.rb
+++ b/Formula/packetbeat-full.rb
@@ -7,8 +7,6 @@ class PacketbeatFull < Formula
   conflicts_with "packetbeat"
   conflicts_with "packetbeat-oss"
 
-  bottle :unneeded
-
   def install
     ["fields.yml", "ingest", "kibana", "module"].each { |d| libexec.install d if File.exist?(d) }
     (libexec/"bin").install "packetbeat"

--- a/Formula/packetbeat-oss.rb
+++ b/Formula/packetbeat-oss.rb
@@ -7,8 +7,6 @@ class PacketbeatOss < Formula
   conflicts_with "packetbeat"
   conflicts_with "packetbeat-full"
 
-  bottle :unneeded
-
   def install
     ["fields.yml", "ingest", "kibana", "module"].each { |d| libexec.install d if File.exist?(d) }
     (libexec/"bin").install "packetbeat"


### PR DESCRIPTION
Removes deprecated `bottle :unneeded` declarations that spit out warnings in `brew` command outputs.

This PR is a duplicate of https://github.com/elastic/homebrew-tap/pull/106 just to speed things up a bit.