### PR TITLE
Sync main with 7.15.2

### DIFF
--- a/Formula/apm-server-full.rb
+++ b/Formula/apm-server-full.rb
@@ -1,9 +1,9 @@
 class ApmServerFull < Formula
   desc "Server for shipping APM metrics to Elasticsearch"
   homepage "https://www.elastic.co/"
-  url "https://artifacts.elastic.co/downloads/apm-server/apm-server-7.15.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
-  version "7.15.1"
-  sha256 "59b6834f9181fcd22eb50decf121e7ddfbbaf7b6d697abd4c579aa2d47733cdb"
+  url "https://artifacts.elastic.co/downloads/apm-server/apm-server-7.15.2-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+  version "7.15.2"
+  sha256 "bc74fa3f665ed19357abbd424ee70d1afbe7f4b416f64b2215c366ee6582760f"
   conflicts_with "apm-server"
   conflicts_with "apm-server-oss"
 

--- a/Formula/apm-server-oss.rb
+++ b/Formula/apm-server-oss.rb
@@ -1,9 +1,9 @@
 class ApmServerOss < Formula
   desc "Server for shipping APM metrics to Elasticsearch"
   homepage "https://www.elastic.co/"
-  url "https://artifacts.elastic.co/downloads/apm-server/apm-server-oss-7.15.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
-  version "7.15.1"
-  sha256 "6d464306c184cd72c42c9d0c19b6f4af6154b219298e56a988201163d463e378"
+  url "https://artifacts.elastic.co/downloads/apm-server/apm-server-oss-7.15.2-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+  version "7.15.2"
+  sha256 "9340b11c98b431f472ee3a52ad2ace2184bc790e6c59fa1c8c55dbf07e7a8663"
   conflicts_with "apm-server"
   conflicts_with "apm-server-full"
 

--- a/Formula/auditbeat-full.rb
+++ b/Formula/auditbeat-full.rb
@@ -1,9 +1,9 @@
 class AuditbeatFull < Formula
   desc "Lightweight Shipper for Audit Data"
   homepage "https://www.elastic.co/products/beats/auditbeat"
-  url "https://artifacts.elastic.co/downloads/beats/auditbeat/auditbeat-7.15.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
-  version "7.15.1"
-  sha256 "8d847b076e319bba36ec17d084d898234eddbbf65d44351afbd2f5099996f68d"
+  url "https://artifacts.elastic.co/downloads/beats/auditbeat/auditbeat-7.15.2-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+  version "7.15.2"
+  sha256 "238022cb1a9e8af8353bf2e8865c76d9b871628641f82bd92e245b8513141514"
   conflicts_with "auditbeat"
   conflicts_with "auditbeat-oss"
 

--- a/Formula/auditbeat-oss.rb
+++ b/Formula/auditbeat-oss.rb
@@ -1,9 +1,9 @@
 class AuditbeatOss < Formula
   desc "Lightweight Shipper for Audit Data"
   homepage "https://www.elastic.co/products/beats/auditbeat"
-  url "https://artifacts.elastic.co/downloads/beats/auditbeat/auditbeat-oss-7.15.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
-  version "7.15.1"
-  sha256 "60667aa4b599b5ec68a6e2d05d3588e758ea59a02b862b790965d4d6729340d1"
+  url "https://artifacts.elastic.co/downloads/beats/auditbeat/auditbeat-oss-7.15.2-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+  version "7.15.2"
+  sha256 "a9894692f823857120e75f60dfee0836ed4e32ed2df8537280bf8d3676477acb"
   conflicts_with "auditbeat"
   conflicts_with "auditbeat-full"
 

--- a/Formula/elasticsearch-full.rb
+++ b/Formula/elasticsearch-full.rb
@@ -1,9 +1,9 @@
 class ElasticsearchFull < Formula
   desc "Distributed search & analytics engine"
   homepage "https://www.elastic.co/products/elasticsearch"
-  url "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.15.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
-  version "7.15.1"
-  sha256 "ad093b4fe6773363fbc9c17d32a89222e536899b2a41c8dcc47b82a9c1459b6c"
+  url "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.15.2-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+  version "7.15.2"
+  sha256 "b9a834ed68f9c67c3f65deb0c9ea78ad32ee22330f907cf2c6db7e7868aa7390"
   conflicts_with "elasticsearch"
 
   def cluster_name

--- a/Formula/filebeat-full.rb
+++ b/Formula/filebeat-full.rb
@@ -1,9 +1,9 @@
 class FilebeatFull < Formula
   desc "File harvester to ship log files to Elasticsearch or Logstash"
   homepage "https://www.elastic.co/products/beats/filebeat"
-  url "https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-7.15.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
-  version "7.15.1"
-  sha256 "94112d02fcf6a63cbdbb6bbaeee999ef6c5ee387ad1e39e32c15f8bbc996dc95"
+  url "https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-7.15.2-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+  version "7.15.2"
+  sha256 "0b60df9aaeda135734b73b507782cafdde35da890a795f89f62c14fbb16d664f"
   conflicts_with "filebeat"
   conflicts_with "filebeat-oss"
 

--- a/Formula/filebeat-oss.rb
+++ b/Formula/filebeat-oss.rb
@@ -1,9 +1,9 @@
 class FilebeatOss < Formula
   desc "File harvester to ship log files to Elasticsearch or Logstash"
   homepage "https://www.elastic.co/products/beats/filebeat"
-  url "https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-oss-7.15.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
-  version "7.15.1"
-  sha256 "7c73ab913ec293388f236f4ecd90877ec4bbbfd67d1a934a45703ecd7fc506a1"
+  url "https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-oss-7.15.2-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+  version "7.15.2"
+  sha256 "695a286e838ca07acd7c37507f6a5b4924642058baf14e3d617a2e2865928009"
   conflicts_with "filebeat"
   conflicts_with "filebeat-full"
 

--- a/Formula/heartbeat-full.rb
+++ b/Formula/heartbeat-full.rb
@@ -1,9 +1,9 @@
 class HeartbeatFull < Formula
   desc "Lightweight Shipper for Uptime Monitoring"
   homepage "https://www.elastic.co/products/beats/heartbeat"
-  url "https://artifacts.elastic.co/downloads/beats/heartbeat/heartbeat-7.15.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
-  version "7.15.1"
-  sha256 "7f28dcc0a1fafe9fdfdd3fa1ba2514ff1bfe5c2cbc1434788c90acb0bf49c369"
+  url "https://artifacts.elastic.co/downloads/beats/heartbeat/heartbeat-7.15.2-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+  version "7.15.2"
+  sha256 "3a2fe6722345f1a53029d639af5a72f6e421243ae4787ced3966de81a39c8fcb"
   conflicts_with "heartbeat"
   conflicts_with "heartbeat-oss"
 

--- a/Formula/heartbeat-oss.rb
+++ b/Formula/heartbeat-oss.rb
@@ -1,9 +1,9 @@
 class HeartbeatOss < Formula
   desc "Lightweight Shipper for Uptime Monitoring"
   homepage "https://www.elastic.co/products/beats/heartbeat"
-  url "https://artifacts.elastic.co/downloads/beats/heartbeat/heartbeat-oss-7.15.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
-  version "7.15.1"
-  sha256 "62f3ba1f862954603b0d9923ff5327e2ee2e612eda20bcf2bb269a9c30c084d6"
+  url "https://artifacts.elastic.co/downloads/beats/heartbeat/heartbeat-oss-7.15.2-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+  version "7.15.2"
+  sha256 "9a269c0b8c3fa631c670db8ecb92abaf58ec1a7e1a142896f239f046a3ca03aa"
   conflicts_with "heartbeat"
   conflicts_with "heartbeat-full"
 

--- a/Formula/kibana-full.rb
+++ b/Formula/kibana-full.rb
@@ -1,9 +1,9 @@
 class KibanaFull < Formula
   desc "Analytics and search dashboard for Elasticsearch"
   homepage "https://www.elastic.co/products/kibana"
-  url "https://artifacts.elastic.co/downloads/kibana/kibana-7.15.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
-  version "7.15.1"
-  sha256 "7028495cafc4c3454d933b3bd938bfc3b7ee9042323df6013d7233306feac3ef"
+  url "https://artifacts.elastic.co/downloads/kibana/kibana-7.15.2-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+  version "7.15.2"
+  sha256 "bcfb9ef7c6f9670ca86eeaba1f009a01773415e00a029bfc862837ea581c6a4f"
   conflicts_with "kibana"
 
   def install

--- a/Formula/logstash-full.rb
+++ b/Formula/logstash-full.rb
@@ -1,9 +1,9 @@
 class LogstashFull < Formula
   desc "Tool for managing events and logs"
   homepage "https://www.elastic.co/products/logstash"
-  url "https://artifacts.elastic.co/downloads/logstash/logstash-7.15.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
-  version "7.15.1"
-  sha256 "f2b375146012a50e596d435d454f9aa4d5ceec8401a94f10b6a696b95747f8ae"
+  url "https://artifacts.elastic.co/downloads/logstash/logstash-7.15.2-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+  version "7.15.2"
+  sha256 "1ac96b53328dcaf14df279c7616ecbeaeca511561eec3119eaf92f9c760b7629"
   conflicts_with "logstash"
   conflicts_with "logstash-oss"
 

--- a/Formula/logstash-oss.rb
+++ b/Formula/logstash-oss.rb
@@ -1,9 +1,9 @@
 class LogstashOss < Formula
   desc "Tool for managing events and logs"
   homepage "https://www.elastic.co/products/logstash"
-  url "https://artifacts.elastic.co/downloads/logstash/logstash-oss-7.15.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
-  version "7.15.1"
-  sha256 "7fd3b32c129e6bff788d9088606ce17c1a27eabd532303684ef0bde6ee33f86b"
+  url "https://artifacts.elastic.co/downloads/logstash/logstash-oss-7.15.2-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+  version "7.15.2"
+  sha256 "470381bf08553f002d9c5652b913df3fcb6b7d54eec7097426440ed681d98226"
   conflicts_with "logstash"
   conflicts_with "logstash-full"
 

--- a/Formula/metricbeat-full.rb
+++ b/Formula/metricbeat-full.rb
@@ -1,9 +1,9 @@
 class MetricbeatFull < Formula
   desc "Collect metrics from your systems and services"
   homepage "https://www.elastic.co/products/beats/metricbeat"
-  url "https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-7.15.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
-  version "7.15.1"
-  sha256 "aa319a87b3a749e9383bf324a14a6ffb5a609217e904b752b0d1440a702188df"
+  url "https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-7.15.2-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+  version "7.15.2"
+  sha256 "cf9f0d8ada85f7eba44059235d65cb9765f37f83e96a48b4a6f69478d407fd50"
   conflicts_with "metricbeat"
   conflicts_with "metricbeat-oss"
 

--- a/Formula/metricbeat-oss.rb
+++ b/Formula/metricbeat-oss.rb
@@ -1,9 +1,9 @@
 class MetricbeatOss < Formula
   desc "Collect metrics from your systems and services"
   homepage "https://www.elastic.co/products/beats/metricbeat"
-  url "https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-oss-7.15.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
-  version "7.15.1"
-  sha256 "fbf4e26f06e6b7b0c0c9a62480c84e37ea634b2671b1e977caf54faf909ae11b"
+  url "https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-oss-7.15.2-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+  version "7.15.2"
+  sha256 "d6608bd2d4d11dd5638bb28f60a255eb9700d5d6b1031303078ba04aa81ca94e"
   conflicts_with "metricbeat"
   conflicts_with "metricbeat-full"
 

--- a/Formula/packetbeat-full.rb
+++ b/Formula/packetbeat-full.rb
@@ -1,9 +1,9 @@
 class PacketbeatFull < Formula
   desc "Lightweight Shipper for Network Data"
   homepage "https://www.elastic.co/products/beats/packetbeat"
-  url "https://artifacts.elastic.co/downloads/beats/packetbeat/packetbeat-7.15.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
-  version "7.15.1"
-  sha256 "011824033ea1155647a22a828776d5f3ca3c9de34dc53c7dd4e8b408f0d14762"
+  url "https://artifacts.elastic.co/downloads/beats/packetbeat/packetbeat-7.15.2-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+  version "7.15.2"
+  sha256 "779087feab6188c7d034d636695e0c298d236d53e2a3525d2f4d3871158e2f27"
   conflicts_with "packetbeat"
   conflicts_with "packetbeat-oss"
 

--- a/Formula/packetbeat-oss.rb
+++ b/Formula/packetbeat-oss.rb
@@ -1,9 +1,9 @@
 class PacketbeatOss < Formula
   desc "Lightweight Shipper for Network Data"
   homepage "https://www.elastic.co/products/beats/packetbeat"
-  url "https://artifacts.elastic.co/downloads/beats/packetbeat/packetbeat-oss-7.15.1-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
-  version "7.15.1"
-  sha256 "da0983784bf6f5d19fcb190ae4d6a74157e46c3144da2a826d6c634acbfd8cbc"
+  url "https://artifacts.elastic.co/downloads/beats/packetbeat/packetbeat-oss-7.15.2-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+  version "7.15.2"
+  sha256 "13c1aea2b85f82eaf96659b35368d5698021d98afba8a9b468233fa9cb743849"
   conflicts_with "packetbeat"
   conflicts_with "packetbeat-full"
 


### PR DESCRIPTION
Until we figure out what is the best way to make sure users are going to use `main` and not `master`, we need to keep having the releases available from both branches