### PR TITLE
[doc] Document the renaming from master to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This tap is for products in the Elastic stack.
 
 Since October 2021, the default branch is renamed from `master` to `main`.
 
-The `master` branch is no longer updated and will be **deleted on December 1st, 2021**.
+The `master` branch is no longer updated and will be **deleted on June 1st, 2022**.
 
 Please [follow the instructions to update](#how-do-i-ensure-my-configuration-is-up-to-date) your configuration.
 
@@ -44,12 +44,12 @@ a product can not be installed at the same time.
 
 Run the following command to update your configuration:
 
-    brew tap --repair elastic/tap
-    brew update -v
+    brew untap elastic/tap --force
+    brew tap elastic/tap
 
 Verify your configuration is based on the `main` branch with:
 
-    git -C /opt/homebrew/Library/Taps/elastic/homebrew-tap status
+    git -C /usr/local/homebrew/Library/Taps/elastic/homebrew-tap status
 
 You should have the following output:
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You should have the following output:
 ### Calling bottle :unneeded is deprecated!
 
 When I execute `brew update`, the following warning appears
-  ```
-  Warning: Calling bottle :unneeded is deprecated! There is no replacement.
-  ```
-  This is related to your configuration not being up-to-date. Your are still using the legacy `master` branch which is not updated anymore. Please [follow the instructions to update](#how-do-i-ensure-my-configuration-is-up-to-date) your local configuration to use the `main` branch.
+
+    Warning: Calling bottle :unneeded is deprecated! There is no replacement.
+
+This is related to your configuration not being up-to-date. Your are still using the legacy `master` branch which is not updated anymore. Please [follow the instructions to update](#how-do-i-ensure-my-configuration-is-up-to-date) your local configuration to use the `main` branch.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This tap is for products in the Elastic stack.
 
 Since October 2021, the default branch is renamed from `master` to `main`.
 
-The `master` branch is no longer updated and will be **deleted on June 1st, 2022**.
+The `master` branch is no longer updated and will be **deleted on June 1st, 2023**.
 
 Please [follow the instructions to update](#how-do-i-ensure-my-configuration-is-up-to-date) your configuration.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 This tap is for products in the Elastic stack.
 
+**WARNING: main is now the default branch**
+
+Since October 2021, the default branch is renamed from `master` to `main`.
+
+The `master` branch is no longer updated and will be **deleted on December 1st, 2021**.
+
+Please [follow the instructions to update](#how-do-i-ensure-my-configuration-is-up-to-date) your configuration.
+
+
 ## How do I install these formulae?
 
 Install the tap via:
@@ -31,5 +40,30 @@ too; replace `-full` with `-oss` in any of the above commands to install the
 OSS distribution. Note that the default distribution and OSS distribution of
 a product can not be installed at the same time.
 
+## How do I ensure my configuration is up to date?
+
+Run the following command to update your configuration:
+
+    brew tap --repair
+    brew update -v
+
+Verify your configuration is based on the `main` branch with:
+
+    git -C /opt/homebrew/Library/Taps/elastic/homebrew-tap status
+
+You should have the following output:
+
+    On branch main
+    Your branch is up to date with 'origin/main'.
+
 ## Documentation
 `brew help`, `man brew` or check [Homebrew's documentation](https://github.com/Homebrew/brew/blob/master/docs/README.md).
+
+## Troubleshooting
+### Calling bottle :unneeded is deprecated!
+
+When I execute `brew update`, the following warning appears
+  ```
+  Warning: Calling bottle :unneeded is deprecated! There is no replacement.
+  ```
+  This is related to your configuration not being up-to-date. Your are still using the legacy `master` branch which is not updated anymore. Please [follow the instructions to update](#how-do-i-ensure-my-configuration-is-up-to-date) your local configuration to use the `main` branch.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ too; replace `-full` with `-oss` in any of the above commands to install the
 OSS distribution. Note that the default distribution and OSS distribution of
 a product can not be installed at the same time.
 
-## How do I ensure my configuration is up to date?
+## How do I ensure my configuration is still up to date after the branch renaming?
 
 Run the following command to update your configuration:
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ a product can not be installed at the same time.
 
 Run the following command to update your configuration:
 
-    brew tap --repair
+    brew tap --repair elastic/tap
     brew update -v
 
 Verify your configuration is based on the `main` branch with:


### PR DESCRIPTION
The default branch is now `main` instead of `master`.

The `master` branch is not updated anymore, and therefore
can generate some warning messages.

This commit adds instructions to explain how to update
the local configuration to point to the new `main` branch.

Relates #115 #110