### PR TITLE
Use `aarch64` packages on ARM-based CPUs

### DIFF
--- a/.ci/update.sh
+++ b/.ci/update.sh
@@ -14,6 +14,10 @@ log() {
   echo "[homebrew-updater] $1"
 }
 
+get_sha256() {
+  echo $(curl $1 | shasum -a 256 | cut -d ' ' -f 1)
+}
+
 update() {
   FORMULA_FILE=$1
   ARTIFACT_PATH=$2
@@ -55,6 +59,40 @@ update() {
   brew uninstall --formula "$FORMULA_FILE"
 }
 
+update_multiarch() {
+  FORMULA_FILE=$1
+  X86_64_ARTIFACT_PATH=$2
+  AARCH64_ARTIFACT_PATH=$3
+
+  X86_64_NEW_URL="$DOWNLOAD_BASE/$X86_64_ARTIFACT_PATH?$DOWNLOAD_ARGS"
+  AARCH64_NEW_URL="$DOWNLOAD_BASE/$AARCH64_ARTIFACT_PATH?$DOWNLOAD_ARGS"
+
+  X86_64_SHASUM=$(get_sha256 $X86_64_NEW_URL)
+  AARCH64_SHASUM=$(get_sha256 $AARCH64_NEW_URL)
+
+  log "Replacing the url, version, and setting the sha256 of the formula '${FORMULA_FILE}'."
+  /usr/bin/sed -i '' \
+    -e "s~^  url \".*aarch.*\"$~  url \"$AARCH64_NEW_URL\"~" \
+    -e "s~^  url \".*x86_64.*\"$~  url \"$X86_64_NEW_URL\"~" \
+    -e "s~^  version \".*\"$~  version \"$VERSION\"~" \
+    -e "s~^  sha256_x86_64 = \".*\"$~  sha256_x86_64 = \"$X86_64_SHASUM\"~" \
+    -e "s~^  sha256_aarch64 = \".*\"$~  sha256_aarch64 = \"$AARCH64_SHASUM\"~" \
+    "$FORMULA_FILE"
+
+  log "Installing '${FORMULA_FILE}'."
+  if BREW_INSTALL_OUTPUT=$(brew install --formula "$FORMULA_FILE" 2>&1)
+  then
+    echo "$BREW_INSTALL_OUTPUT"
+    log "Install successful."
+  else
+    echo "$BREW_INSTALL_OUTPUT"
+    log "The install was unsuccessful, aborting."
+    exit 1
+  fi
+
+  brew uninstall --formula "$FORMULA_FILE"
+}
+
 log "Using brew: '$(which brew)'."
 
 update "./Formula/apm-server-full.rb" "apm-server/apm-server-$VERSION-darwin-x86_64.tar.gz"
@@ -66,15 +104,21 @@ fi
 
 update "./Formula/auditbeat-full.rb" "beats/auditbeat/auditbeat-$VERSION-darwin-x86_64.tar.gz"
 update "./Formula/auditbeat-oss.rb" "beats/auditbeat/auditbeat-oss-$VERSION-darwin-x86_64.tar.gz"
-update "./Formula/elasticsearch-full.rb" "elasticsearch/elasticsearch-$VERSION-darwin-x86_64.tar.gz"
 update "./Formula/filebeat-full.rb" "beats/filebeat/filebeat-$VERSION-darwin-x86_64.tar.gz"
 update "./Formula/filebeat-oss.rb" "beats/filebeat/filebeat-oss-$VERSION-darwin-x86_64.tar.gz"
 update "./Formula/heartbeat-full.rb" "beats/heartbeat/heartbeat-$VERSION-darwin-x86_64.tar.gz"
 update "./Formula/heartbeat-oss.rb" "beats/heartbeat/heartbeat-oss-$VERSION-darwin-x86_64.tar.gz"
-update "./Formula/kibana-full.rb" "kibana/kibana-$VERSION-darwin-x86_64.tar.gz"
 update "./Formula/logstash-full.rb" "logstash/logstash-$VERSION-darwin-x86_64.tar.gz"
 update "./Formula/logstash-oss.rb" "logstash/logstash-oss-$VERSION-darwin-x86_64.tar.gz"
 update "./Formula/metricbeat-full.rb" "beats/metricbeat/metricbeat-$VERSION-darwin-x86_64.tar.gz"
 update "./Formula/metricbeat-oss.rb" "beats/metricbeat/metricbeat-oss-$VERSION-darwin-x86_64.tar.gz"
 update "./Formula/packetbeat-full.rb" "beats/packetbeat/packetbeat-$VERSION-darwin-x86_64.tar.gz"
 update "./Formula/packetbeat-oss.rb" "beats/packetbeat/packetbeat-oss-$VERSION-darwin-x86_64.tar.gz"
+
+update_multiarch "./Formula/elasticsearch-full.rb" \
+  "elasticsearch/elasticsearch-$VERSION-darwin-x86_64.tar.gz" \
+  "elasticsearch/elasticsearch-$VERSION-darwin-aarch64.tar.gz"
+
+update_multiarch "./Formula/kibana-full.rb" \
+  "kibana/kibana-$VERSION-darwin-x86_64.tar.gz" \
+  "kibana/kibana-$VERSION-darwin-aarch64.tar.gz"

--- a/Formula/elasticsearch-full.rb
+++ b/Formula/elasticsearch-full.rb
@@ -1,9 +1,15 @@
 class ElasticsearchFull < Formula
   desc "Distributed search & analytics engine"
   homepage "https://www.elastic.co/products/elasticsearch"
-  url "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.16.3-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
-  version "7.16.3"
-  sha256 "213faf4db506c9781d322370ffa6d55e446788694ca41ed141138fa5dcbc4064"
+  if Hardware::CPU.arm?
+    url "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.16.3-darwin-aarch64.tar.gz?tap=elastic/homebrew-tap"
+    version "7.16.3"
+    sha256 "5829ead77ca856a1fd21bc2269dd7b0afe3daa820cfde2d17939fe40fe71c4cb"
+  else
+    url "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.16.3-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+    version "7.16.3"
+    sha256 "213faf4db506c9781d322370ffa6d55e446788694ca41ed141138fa5dcbc4064"
+  end
   conflicts_with "elasticsearch"
 
   def cluster_name
@@ -41,7 +47,11 @@ class ElasticsearchFull < Formula
     end
     bin.env_script_all_files(libexec/"bin", {})
 
-    system "codesign", "-f", "-s", "-", "#{libexec}/modules/x-pack-ml/platform/darwin-x86_64/controller.app", "--deep"
+    if Hardware::CPU.arm?
+      system "codesign", "-f", "-s", "-", "#{libexec}/modules/x-pack-ml/platform/darwin-aarch64/controller.app", "--deep"
+    else
+      system "codesign", "-f", "-s", "-", "#{libexec}/modules/x-pack-ml/platform/darwin-x86_64/controller.app", "--deep"
+    end
     system "find", "#{libexec}/jdk.app/Contents/Home/bin", "-type", "f", "-exec", "codesign", "-f", "-s", "-", "{}", ";"
   end
 

--- a/Formula/elasticsearch-full.rb
+++ b/Formula/elasticsearch-full.rb
@@ -1,14 +1,17 @@
 class ElasticsearchFull < Formula
   desc "Distributed search & analytics engine"
   homepage "https://www.elastic.co/products/elasticsearch"
+
+  sha256_aarch64 = "5829ead77ca856a1fd21bc2269dd7b0afe3daa820cfde2d17939fe40fe71c4cb"
+  sha256_x86_64 = "213faf4db506c9781d322370ffa6d55e446788694ca41ed141138fa5dcbc4064"
   if Hardware::CPU.arm?
     url "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.16.3-darwin-aarch64.tar.gz?tap=elastic/homebrew-tap"
     version "7.16.3"
-    sha256 "5829ead77ca856a1fd21bc2269dd7b0afe3daa820cfde2d17939fe40fe71c4cb"
+    sha256 sha256_aarch64
   else
     url "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.16.3-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
     version "7.16.3"
-    sha256 "213faf4db506c9781d322370ffa6d55e446788694ca41ed141138fa5dcbc4064"
+    sha256 sha256_x86_64
   end
   conflicts_with "elasticsearch"
 

--- a/Formula/kibana-full.rb
+++ b/Formula/kibana-full.rb
@@ -1,14 +1,17 @@
 class KibanaFull < Formula
   desc "Analytics and search dashboard for Elasticsearch"
   homepage "https://www.elastic.co/products/kibana"
+
+  sha256_aarch64 = "dd06dfcbc54c8bff093c723aa8d166e9ff2ce8eb0382621b5060b8e77caf5ecb"
+  sha256_x86_64 = "0edd4e06a021438c3531875955cabf2aba5bab49e5161f5cda087181e5d11625"
   if Hardware::CPU.arm?
     url "https://artifacts.elastic.co/downloads/kibana/kibana-7.16.3-darwin-aarch64.tar.gz?tap=elastic/homebrew-tap"
     version "7.16.3"
-    sha256 "dd06dfcbc54c8bff093c723aa8d166e9ff2ce8eb0382621b5060b8e77caf5ecb"
+    sha256 sha256_aarch64
   else
     url "https://artifacts.elastic.co/downloads/kibana/kibana-7.16.3-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
     version "7.16.3"
-    sha256 "0edd4e06a021438c3531875955cabf2aba5bab49e5161f5cda087181e5d11625"
+    sha256 sha256_x86_64
   end
   conflicts_with "kibana"
 

--- a/Formula/kibana-full.rb
+++ b/Formula/kibana-full.rb
@@ -1,9 +1,15 @@
 class KibanaFull < Formula
   desc "Analytics and search dashboard for Elasticsearch"
   homepage "https://www.elastic.co/products/kibana"
-  url "https://artifacts.elastic.co/downloads/kibana/kibana-7.16.3-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
-  version "7.16.3"
-  sha256 "0edd4e06a021438c3531875955cabf2aba5bab49e5161f5cda087181e5d11625"
+  if Hardware::CPU.arm?
+    url "https://artifacts.elastic.co/downloads/kibana/kibana-7.16.3-darwin-aarch64.tar.gz?tap=elastic/homebrew-tap"
+    version "7.16.3"
+    sha256 "dd06dfcbc54c8bff093c723aa8d166e9ff2ce8eb0382621b5060b8e77caf5ecb"
+  else
+    url "https://artifacts.elastic.co/downloads/kibana/kibana-7.16.3-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap"
+    version "7.16.3"
+    sha256 "0edd4e06a021438c3531875955cabf2aba5bab49e5161f5cda087181e5d11625"
+  end
   conflicts_with "kibana"
 
   def install


### PR DESCRIPTION
This change ensures that on ARM-based macs, the `aarch64` packages are
used, leading to better performance, less resource utilization and
better battery usage.

Closes #89