### PR TITLE
Switch to modern service definition for elasticsearch-full

### DIFF
--- a/Formula/elasticsearch-full.rb
+++ b/Formula/elasticsearch-full.rb
@@ -65,36 +65,11 @@ class ElasticsearchFull < Formula
     s
   end
 
-  plist_options :manual => "elasticsearch"
-
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-        <dict>
-          <key>KeepAlive</key>
-          <false/>
-          <key>Label</key>
-          <string>#{plist_name}</string>
-          <key>ProgramArguments</key>
-          <array>
-            <string>#{opt_bin}/elasticsearch</string>
-          </array>
-          <key>EnvironmentVariables</key>
-          <dict>
-          </dict>
-          <key>RunAtLoad</key>
-          <true/>
-          <key>WorkingDirectory</key>
-          <string>#{var}</string>
-          <key>StandardErrorPath</key>
-          <string>#{var}/log/elasticsearch.log</string>
-          <key>StandardOutPath</key>
-          <string>#{var}/log/elasticsearch.log</string>
-        </dict>
-      </plist>
-    EOS
+  service do
+    run [opt_bin/"elasticsearch", "--config", etc/"mongod.conf"]
+    working_dir var
+    log_path var/"log/elasticsearch.log"
+    error_log_path var/"log/elasticsearch.log"
   end
 
   test do

--- a/Formula/elasticsearch-full.rb
+++ b/Formula/elasticsearch-full.rb
@@ -66,7 +66,7 @@ class ElasticsearchFull < Formula
   end
 
   service do
-    run [opt_bin/"elasticsearch", "--config", etc/"mongod.conf"]
+    run [opt_bin/"elasticsearch"]
     working_dir var
     log_path var/"log/elasticsearch.log"
     error_log_path var/"log/elasticsearch.log"


### PR DESCRIPTION
Summary: Homebrew has officially deprecated the `plist_options` command
Example warning message: `Warning: Calling plist_options is deprecated! Use service.require_root instead.`

See https://github.com/mongodb/homebrew-brew/pull/174 for most details