### PR TITLE
Fix plist_options deprecation warning

### DIFF
--- a/Formula/elasticsearch-full.rb
+++ b/Formula/elasticsearch-full.rb
@@ -65,36 +65,11 @@ class ElasticsearchFull < Formula
     s
   end
 
-  plist_options :manual => "elasticsearch"
-
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-        <dict>
-          <key>KeepAlive</key>
-          <false/>
-          <key>Label</key>
-          <string>#{plist_name}</string>
-          <key>ProgramArguments</key>
-          <array>
-            <string>#{opt_bin}/elasticsearch</string>
-          </array>
-          <key>EnvironmentVariables</key>
-          <dict>
-          </dict>
-          <key>RunAtLoad</key>
-          <true/>
-          <key>WorkingDirectory</key>
-          <string>#{var}</string>
-          <key>StandardErrorPath</key>
-          <string>#{var}/log/elasticsearch.log</string>
-          <key>StandardOutPath</key>
-          <string>#{var}/log/elasticsearch.log</string>
-        </dict>
-      </plist>
-    EOS
+  service do
+    run "#{opt_bin}/elasticsearch"
+    working_dir "#{var}"
+    error_log_path "#{var}/log/elasticsearch.log"
+    log_path "#{var}/log/elasticsearch.log"
   end
 
   test do


### PR DESCRIPTION
Fixes: https://github.com/elastic/homebrew-tap/issues/143

> Warning: Calling plist_options is deprecated! Use service.require_root instead.