### PR TITLE
Update kibana-full.rb change plist_options to service.require_root

### DIFF
--- a/Formula/kibana-full.rb
+++ b/Formula/kibana-full.rb
@@ -47,23 +47,11 @@ class KibanaFull < Formula
   EOS
   end
 
-  service.require_root :manual => "kibana"
-
-  def plist; <<~EOS
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN"
-    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-      <dict>
-        <key>Label</key>
-        <string>#{plist_name}</string>
-        <key>Program</key>
-        <string>#{opt_bin}/kibana</string>
-        <key>RunAtLoad</key>
-        <true/>
-      </dict>
-    </plist>
-  EOS
+  service do
+    run [opt_bin/"kibana"]
+    working_dir var
+    log_path var/"log/kibana.log"
+    error_log_path var/"log/kibana.log"
   end
 
   test do

--- a/Formula/kibana-full.rb
+++ b/Formula/kibana-full.rb
@@ -47,7 +47,7 @@ class KibanaFull < Formula
   EOS
   end
 
-  plist_options :manual => "kibana"
+  service.require_root :manual => "kibana"
 
   def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
Attempting to download kibana for elasticsearch using homebrew on an M1 mac resulted in this error: `Calling plist_options is disabled! Use service.require_root instead.
Please report this issue to the elastic/tap tap (not Homebrew/brew or Homebrew/homebrew-core), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/elastic/homebrew-tap/Formula/kibana-full.rb:50`

This is the PR to fix it, as suggested by the prompt. The fix is simply substituting `plist_options` with `service.require_root` 

This PR is inspired by a similar PR for mongoDb https://github.com/mongodb/homebrew-brew/pull/176/files

Kibana seems like a really cool visualization tool for my performance testing results and I want myself and future users to be able to leverage this tool. 

