### PR TITLE
Fixes elastic/homebrew-tap/issues/#146

### DIFF
--- a/Formula/elasticsearch-full.rb
+++ b/Formula/elasticsearch-full.rb
@@ -65,7 +65,7 @@ class ElasticsearchFull < Formula
     s
   end
 
-  plist_options :manual => "elasticsearch"
+  @plist_manual = "elasticsearch"
 
   def plist
     <<~EOS

--- a/Formula/logstash-full.rb
+++ b/Formula/logstash-full.rb
@@ -40,7 +40,7 @@ class LogstashFull < Formula
   EOS
   end
 
-  plist_options :manual => "logstash"
+  @plist_manual = "logstash"
 
   def plist
     <<~EOS


### PR DESCRIPTION
The error is as follows

% brew install elastic/tap/elasticsearch-full
Error: elastic/tap/elasticsearch-full: Calling plist_options is disabled! Use service.require_root instead. Please report this issue to the elastic/tap tap (not Homebrew/brew or Homebrew/homebrew-core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/elastic/homebrew-tap/Formula/elasticsearch-full.rb:68

This fixes it.