### PR TITLE
replace deprecated plist_options

### DIFF
--- a/Formula/apm-server-full.rb
+++ b/Formula/apm-server-full.rb
@@ -29,7 +29,7 @@ class ApmServerFull < Formula
     (var/"log/apm-server").mkpath
   end
 
-  plist_options :manual => "apm-server"
+  @plist_manual = "apm-server"
 
   def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>

--- a/Formula/apm-server-oss.rb
+++ b/Formula/apm-server-oss.rb
@@ -29,7 +29,7 @@ class ApmServerOss < Formula
     (var/"log/apm-server").mkpath
   end
 
-  plist_options :manual => "apm-server"
+  @plist_manual = "apm-server"
 
   def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>

--- a/Formula/auditbeat-full.rb
+++ b/Formula/auditbeat-full.rb
@@ -29,7 +29,7 @@ class AuditbeatFull < Formula
     (var/"log/auditbeat").mkpath
   end
 
-  plist_options :manual => "auditbeat"
+  @plist_manual = "auditbeat"
 
   def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>

--- a/Formula/auditbeat-oss.rb
+++ b/Formula/auditbeat-oss.rb
@@ -29,7 +29,7 @@ class AuditbeatOss < Formula
     (var/"log/auditbeat").mkpath
   end
 
-  plist_options :manual => "auditbeat"
+  @plist_manual = "auditbeat"
 
   def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>

--- a/Formula/elasticsearch-full.rb
+++ b/Formula/elasticsearch-full.rb
@@ -65,7 +65,7 @@ class ElasticsearchFull < Formula
     s
   end
 
-  plist_options :manual => "elasticsearch"
+  @plist_manual = "elasticsearch"
 
   def plist
     <<~EOS

--- a/Formula/filebeat-full.rb
+++ b/Formula/filebeat-full.rb
@@ -24,7 +24,7 @@ class FilebeatFull < Formula
     EOS
   end
 
-  plist_options :manual => "filebeat"
+  @plist_manual = "filebeat"
 
   def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>

--- a/Formula/filebeat-oss.rb
+++ b/Formula/filebeat-oss.rb
@@ -24,7 +24,7 @@ class FilebeatOss < Formula
     EOS
   end
 
-  plist_options :manual => "filebeat"
+  @plist_manual = "filebeat"
 
   def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>

--- a/Formula/heartbeat-full.rb
+++ b/Formula/heartbeat-full.rb
@@ -29,7 +29,7 @@ class HeartbeatFull < Formula
     (var/"log/heartbeat").mkpath
   end
 
-  plist_options :manual => "heartbeat"
+  @plist_manual = "heartbeat"
 
   def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>

--- a/Formula/heartbeat-oss.rb
+++ b/Formula/heartbeat-oss.rb
@@ -29,7 +29,7 @@ class HeartbeatOss < Formula
     (var/"log/heartbeat").mkpath
   end
 
-  plist_options :manual => "heartbeat"
+  @plist_manual = "heartbeat"
 
   def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>

--- a/Formula/kibana-full.rb
+++ b/Formula/kibana-full.rb
@@ -47,7 +47,7 @@ class KibanaFull < Formula
   EOS
   end
 
-  plist_options :manual => "kibana"
+  @plist_manual = "kibana"
 
   def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>

--- a/Formula/logstash-full.rb
+++ b/Formula/logstash-full.rb
@@ -40,7 +40,7 @@ class LogstashFull < Formula
   EOS
   end
 
-  plist_options :manual => "logstash"
+  @plist_manual = "logstash"
 
   def plist
     <<~EOS

--- a/Formula/logstash-oss.rb
+++ b/Formula/logstash-oss.rb
@@ -40,7 +40,7 @@ class LogstashOss < Formula
   EOS
   end
 
-  plist_options :manual => "logstash"
+  @plist_manual = "logstash"
 
   def plist
     <<~EOS

--- a/Formula/metricbeat-full.rb
+++ b/Formula/metricbeat-full.rb
@@ -24,7 +24,7 @@ class MetricbeatFull < Formula
     EOS
   end
 
-  plist_options :manual => "metricbeat"
+  @plist_manual = "metricbeat"
 
   def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>

--- a/Formula/metricbeat-oss.rb
+++ b/Formula/metricbeat-oss.rb
@@ -24,7 +24,7 @@ class MetricbeatOss < Formula
     EOS
   end
 
-  plist_options :manual => "metricbeat"
+  @plist_manual = "metricbeat"
 
   def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>

--- a/Formula/packetbeat-full.rb
+++ b/Formula/packetbeat-full.rb
@@ -24,7 +24,7 @@ class PacketbeatFull < Formula
     EOS
   end
 
-  plist_options :manual => "packetbeat"
+  @plist_manual = "packetbeat"
 
   def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>

--- a/Formula/packetbeat-oss.rb
+++ b/Formula/packetbeat-oss.rb
@@ -24,7 +24,7 @@ class PacketbeatOss < Formula
     EOS
   end
 
-  plist_options :manual => "packetbeat"
+  @plist_manual = "packetbeat"
 
   def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
Fixes for the following: 
```ruby
Calling plist_options is disabled! Use service.require_root instead
```