### PR TITLE
Replace deprecated pathutils.rmtree by FileUtils.remove_dir

### DIFF
--- a/Formula/elasticsearch-full.rb
+++ b/Formula/elasticsearch-full.rb
@@ -32,7 +32,9 @@ class ElasticsearchFull < Formula
 
     # Move config files into etc
     (etc/"elasticsearch").install Dir[libexec/"config/*"]
-    (libexec/"config").rmtree
+
+    require 'fileutils'
+    FileUtils.remove_dir (libexec/"config")
 
     Dir.foreach(libexec/"bin") do |f|
       next if f == "." || f == ".." || !File.extname(f).empty?


### PR DESCRIPTION
Installing elasticsearch-full fails with a MethodDeprecatedError. Replace pathutils.rmtree by fileutils.remove_dir.
Fixes #173 