### PR TITLE
Fix installation issues for `elasticsearch-full`, `logstash-full`, and `logstash-oss`

### DIFF
--- a/Formula/elasticsearch-full.rb
+++ b/Formula/elasticsearch-full.rb
@@ -32,7 +32,7 @@ class ElasticsearchFull < Formula
 
     # Move config files into etc
     (etc/"elasticsearch").install Dir[libexec/"config/*"]
-    (libexec/"config").rmtree
+    FileUtils.rm_r(libexec/"config")
 
     Dir.foreach(libexec/"bin") do |f|
       next if f == "." || f == ".." || !File.extname(f).empty?

--- a/Formula/logstash-full.rb
+++ b/Formula/logstash-full.rb
@@ -22,7 +22,7 @@ class LogstashFull < Formula
 
     # Move config files into etc
     (etc/"logstash").install Dir[libexec/"config/*"]
-    (libexec/"config").rmtree
+    FileUtils.rm_r(libexec/"config")
 
     bin.install libexec/"bin/logstash", libexec/"bin/logstash-plugin"
     bin.env_script_all_files(libexec/"bin", {})

--- a/Formula/logstash-oss.rb
+++ b/Formula/logstash-oss.rb
@@ -22,7 +22,7 @@ class LogstashOss < Formula
 
     # Move config files into etc
     (etc/"logstash").install Dir[libexec/"config/*"]
-    (libexec/"config").rmtree
+    FileUtils.rm_r(libexec/"config")
 
     bin.install libexec/"bin/logstash", libexec/"bin/logstash-plugin"
     bin.env_script_all_files(libexec/"bin", {})


### PR DESCRIPTION
# What
Fixes installation issues for `elasticsearch-full`, `logstash-full`, and `logstash-oss`.
See related issue: https://github.com/elastic/homebrew-tap/issues/173

# Reason
Fix a MethodDeprecatedError caused by the use of rmtree.


# Quality Assurance
Before
```
$ brew install elasticsearch-full
==> Fetching elastic/tap/elasticsearch-full
==> Downloading https://artifacts.elastic.co/downloads/elasticsear
Already downloaded: /Users/shuto/Library/Caches/Homebrew/downloads/69a42f80a7a14f892ddcb7d63a53c1ccaecce67dc8ffa0ac125be8f31241b01e--elasticsearch-7.17.4-darwin-x86_64.tar.gz
==> Installing elasticsearch-full from elastic/tap
Warning: elasticsearch-full: No available formula with the name "elasticsearch". Did you mean elasticsearch-full?
'conflicts_with "elasticsearch"' should be removed from elasticsearch-full.rb.
Please report this issue to the elastic/homebrew-tap tap
 (not Homebrew/* repositories)!
Warning: Tried to install empty array to /opt/homebrew/etc/elasticsearch/jvm.options.d
Error: An exception occurred within a child process:
  MethodDeprecatedError: Calling rmtree is disabled! Use FileUtils#rm_r instead.
Please report this issue to the elastic/homebrew-tap tap (not Homebrew/* repositories), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/elastic/homebrew-tap/Formula/elasticsearch-full.rb:35
```

After (by using the implementations in my repository)
```
$ brew install elasticsearch-full
==> Fetching shorie000/tap/elasticsearch-full
==> Downloading https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.17.4-darwin-x86_64.tar.gz?tap=elastic/homebrew-tap
Already downloaded: /Users/shuto/Library/Caches/Homebrew/downloads/69a42f80a7a14f892ddcb7d63a53c1ccaecce67dc8ffa0ac125be8f31241b01e--elasticsearch-7.17.4-darwin-x86_64.tar.gz
==> Installing elasticsearch-full from shorie000/tap
Warning: elasticsearch-full: No available formula with the name "elasticsearch". Did you mean elasticsearch-full?
'conflicts_with "elasticsearch"' should be removed from elasticsearch-full.rb.
Please report this issue to the shorie000/homebrew-tap tap
 (not Homebrew/* repositories)!
Warning: Tried to install empty array to /opt/homebrew/etc/elasticsearch/jvm.options.d
==> codesign -f -s - /opt/homebrew/Cellar/elasticsearch-full/7.17.4/libexec/modules/x-pack-ml/platform/darwin-x86_64/controller.app --deep
==> find /opt/homebrew/Cellar/elasticsearch-full/7.17.4/libexec/jdk.app/Contents/Home/bin -type f -exec codesign -f -s - {} ;
==> Caveats
Data:    /opt/homebrew/var/lib/elasticsearch/elasticsearch_shuto/
Logs:    /opt/homebrew/var/log/elasticsearch/elasticsearch_shuto.log
Plugins: /opt/homebrew/var/elasticsearch/plugins/
Config:  /opt/homebrew/etc/elasticsearch/

To start shorie000/tap/elasticsearch-full now and restart at login:
  brew services start shorie000/tap/elasticsearch-full
Or, if you don't want/need a background service you can just run:
  /opt/homebrew/opt/elasticsearch-full/bin/elasticsearch
==> Summary
🍺  /opt/homebrew/Cellar/elasticsearch-full/7.17.4: 948 files, 476.2MB, built in 5 seconds
==> Running `brew cleanup elasticsearch-full`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
```
